### PR TITLE
Allow custom scripts in prefabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 packages
 .vs
+.idea
 bin
 obj
 zip

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -307,13 +307,16 @@ namespace NewHorizons
         {
             var folder = mod.ModHelper.Manifest.ModFolderPath;
 
-            // the mod folder will be searched in when loading assemblies
-            // this lets custom scripts work
+            var dllFiles = Directory.GetFiles(folder + @"planets\", "*.dll", SearchOption.AllDirectories);
             AppDomain.CurrentDomain.AssemblyResolve += (sender, args) => {
                 var name = new AssemblyName(args.Name).Name + ".dll";
-                var path = Path.Combine(folder, name);
-                return File.Exists(path) ? Assembly.LoadFile(path) : null;
+                var file = dllFiles.FirstOrDefault(x => Path.GetFileName(x) == name);
+                return file != null ? Assembly.LoadFile(file) : null;
             };
+            foreach (var file in dllFiles)
+            {
+                Assembly.LoadFile(file);
+            }
 
             foreach (var file in Directory.GetFiles(folder + @"planets\", "*.json", SearchOption.AllDirectories))
             {

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -306,6 +306,15 @@ namespace NewHorizons
         public void LoadConfigs(IModBehaviour mod)
         {
             var folder = mod.ModHelper.Manifest.ModFolderPath;
+
+            // the mod folder will be searched in when loading assemblies
+            // this lets custom scripts work
+            AppDomain.CurrentDomain.AssemblyResolve += (sender, args) => {
+                var name = new AssemblyName(args.Name).Name + ".dll";
+                var path = Path.Combine(folder, name);
+                return File.Exists(path) ? Assembly.LoadFile(path) : null;
+            };
+
             foreach (var file in Directory.GetFiles(folder + @"planets\", "*.json", SearchOption.AllDirectories))
             {
                 try


### PR DESCRIPTION
loads all dlls in the planets folder preemptively, so that assetbundles can find custom scripts.
also adds an assembly resolver that will search thru the planets folder, so references in the dlls will resolve.