### PR TITLE
Added the ability to make custom sky boxes

### DIFF
--- a/NewHorizons/Builder/StarSystem/SkyboxBuilder.cs
+++ b/NewHorizons/Builder/StarSystem/SkyboxBuilder.cs
@@ -1,12 +1,63 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using NewHorizons.External.Configs;
+using NewHorizons.Utility;
+using OWML.Common;
+using UnityEngine;
+using Logger = NewHorizons.Utility.Logger;
+using Object = System.Object;
 
 namespace NewHorizons.Builder.StarSystem
 {
-    class SkyboxBuilder
+    internal class SkyboxBuilder
     {
+        public static Material LoadMaterial(string assetBundle, string path, string uniqueModName, IModBehaviour mod)
+        {
+            string key = uniqueModName + "." + assetBundle;
+            AssetBundle bundle;
+            Material cubemap;
+
+            try
+            {
+                if (Main.AssetBundles.ContainsKey(key)) bundle = Main.AssetBundles[key];
+                else
+                {
+                    bundle = mod.ModHelper.Assets.LoadBundle(assetBundle);
+                    Main.AssetBundles[key] = bundle;
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.LogError($"Couldn't load AssetBundle {assetBundle} : {e.Message}");
+                return null;
+            }
+
+            try
+            {
+                cubemap = bundle.LoadAsset<Material>(path);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Couldn't load asset {path} from AssetBundle {assetBundle} : {e.Message}");
+                return null;
+            }
+
+            return cubemap;
+        }
+
+        public static void Make(StarSystemConfig.SkyboxConfig info, IModBehaviour mod)
+        {
+            Logger.Log("Building Skybox");
+            Material skyBoxMaterial = LoadMaterial(info.assetBundle, info.path, mod.ModHelper.Manifest.UniqueName, mod);
+            RenderSettings.skybox = skyBoxMaterial;
+            DynamicGI.UpdateEnvironment();
+            Main.Instance.ModHelper.Events.Unity.FireOnNextUpdate(() =>
+            {
+                foreach (var camera in Resources.FindObjectsOfTypeAll<OWCamera>())
+                {
+                    camera.clearFlags = CameraClearFlags.Skybox;
+                }
+            });
+        }
+        
     }
 }

--- a/NewHorizons/External/Configs/StarSystemConfig.cs
+++ b/NewHorizons/External/Configs/StarSystemConfig.cs
@@ -14,6 +14,7 @@ namespace NewHorizons.External.Configs
         public bool destroyStockPlanets = true;
         public string factRequiredForWarp;
         public NomaiCoordinates coords;
+        public SkyboxConfig skybox;
 
         public class NomaiCoordinates
         {
@@ -22,6 +23,14 @@ namespace NewHorizons.External.Configs
             public int[] z;
         }
 
+        public class SkyboxConfig
+        {
+            public string assetBundle = null;
+            public string path = null;
+            public bool destroyStarField = false;
+        }
+
         public StarSystemConfig(Dictionary<string, object> dict) : base(dict) { }
+        
     }
 }

--- a/NewHorizons/Handlers/SystemCreationHandler.cs
+++ b/NewHorizons/Handlers/SystemCreationHandler.cs
@@ -5,7 +5,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NewHorizons.Builder.StarSystem;
 using UnityEngine;
+using Logger = NewHorizons.Utility.Logger;
+using Object = UnityEngine.Object;
 
 namespace NewHorizons.Handlers
 {
@@ -17,23 +20,15 @@ namespace NewHorizons.Handlers
 
             var skybox = GameObject.Find("Skybox/Starfield");
 
-            /*
-            skybox.GetComponent<MeshRenderer>().material.shader = Shader.Find("Standard");
-            */
+            if (system.Config.skybox?.destroyStarField ?? false)
+            {
+                Object.Destroy(skybox);
+            }
 
-            /*
-            var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-            GameObject.Destroy(sphere.GetComponent<SphereCollider>());
-
-            sphere.transform.parent = skybox.transform;
-            sphere.transform.localPosition = Vector3.zero;
-
-            var meshFilter = sphere.GetComponent<MeshFilter>();
-            meshFilter.mesh.triangles = meshFilter.mesh.triangles.Reverse().ToArray();
-
-            var meshRenderer = sphere.GetComponent<MeshRenderer>();
-            meshRenderer.material.color = Color.green;
-            */
+            if (system.Config.skybox?.assetBundle != null && system.Config.skybox?.path != null)
+            {
+                SkyboxBuilder.Make(system.Config.skybox, system.Mod);
+            }
 
         }
     }

--- a/NewHorizons/star_system_schema.json
+++ b/NewHorizons/star_system_schema.json
@@ -19,6 +19,25 @@
     "destroyStockPlanets": {
       "type": "bool",
       "description": "Do you want a clean slate for this star system? Or will it be a modified version of the original."
+    },
+    "skybox": {
+      "type": "object",
+      "description": "Options for the skybox of your system",
+      "properties": {
+        "destroyStarField": {
+          "type": "boolean",
+          "description": "Whether to destroy the star field around the player (always set to true if `assetBundle` and `path` is set)",
+          "default": false
+        },
+        "assetBundle": {
+          "type": "string",
+          "description": "Path to the Unity asset bundle to load the skybox material from"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the material within the asset bundle specified by `assetBundle` to use for the skybox"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
You can now add custom skyboxes by making a skybox material in Unity and importing it:
(in a star system config)
```json
{
  "skybox": {
    "assetBundle": "path/to/my/bundle",
    "path": "Assets/path/to/my/material.mat"
  }
}
```
[skybox.zip](https://github.com/xen-42/outer-wilds-new-horizons/files/8644164/skybox.zip) Here's an example bundle, the path of the material is: `Assets/Materials/Skybox.mat`