### PR TITLE
Quantum2

### DIFF
--- a/NewHorizons/Builder/Atmosphere/AirBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/AirBuilder.cs
@@ -5,7 +5,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Atmosphere
 {
-    static class AirBuilder
+    public static class AirBuilder
     {
         public static void Make(GameObject body, Sector sector, AtmosphereModule.AirInfo info)
         {

--- a/NewHorizons/Builder/Atmosphere/AirBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/AirBuilder.cs
@@ -1,4 +1,5 @@
-﻿using OWML.Utils;
+﻿using NewHorizons.External;
+using OWML.Utils;
 using UnityEngine;
 using Logger = NewHorizons.Utility.Logger;
 
@@ -6,16 +7,16 @@ namespace NewHorizons.Builder.Atmosphere
 {
     static class AirBuilder
     {
-        public static void Make(GameObject body, float airScale, bool isRaining, bool hasOxygen)
+        public static void Make(GameObject body, Sector sector, AtmosphereModule.AirInfo info)
         {
             GameObject airGO = new GameObject("Air");
             airGO.SetActive(false);
             airGO.layer = 17;
-            airGO.transform.parent = body.transform;
+            airGO.transform.parent = sector?.transform ?? body.transform;
 
             SphereCollider SC = airGO.AddComponent<SphereCollider>();
             SC.isTrigger = true;
-            SC.radius = airScale;
+            SC.radius = info.Scale;
 
             SimpleFluidVolume SFV = airGO.AddComponent<SimpleFluidVolume>();
             SFV._layer = 5;
@@ -25,12 +26,12 @@ namespace NewHorizons.Builder.Atmosphere
             SFV._allowShipAutoroll = true;
             SFV._disableOnStart = false;
 
-            if(hasOxygen)
+            if(info.HasOxygen)
             {
                 airGO.AddComponent<OxygenVolume>();
             }
 
-            if (isRaining)
+            if (info.IsRaining)
             {
                 VisorRainEffectVolume VREF = airGO.AddComponent<VisorRainEffectVolume>();
                 VREF._rainDirection = VisorRainEffectVolume.RainDirection.Radial;

--- a/NewHorizons/Builder/Atmosphere/AtmosphereBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/AtmosphereBuilder.cs
@@ -6,11 +6,11 @@ namespace NewHorizons.Builder.Atmosphere
 {
     static class AtmosphereBuilder
     {
-        public static void Make(GameObject body, AtmosphereModule atmosphereModule, float surfaceSize)
+        public static void Make(GameObject body, Sector sector, AtmosphereModule atmosphereModule, float surfaceSize)
         {
             GameObject atmoGO = new GameObject("Atmosphere");
             atmoGO.SetActive(false);
-            atmoGO.transform.parent = body.transform;
+            atmoGO.transform.parent = sector?.transform ?? body.transform;
 
             if (atmosphereModule.HasAtmosphere)
             {

--- a/NewHorizons/Builder/Atmosphere/AtmosphereBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/AtmosphereBuilder.cs
@@ -4,7 +4,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Atmosphere
 {
-    static class AtmosphereBuilder
+    public static class AtmosphereBuilder
     {
         public static void Make(GameObject body, Sector sector, AtmosphereModule atmosphereModule, float surfaceSize)
         {

--- a/NewHorizons/Builder/Atmosphere/CloudsBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/CloudsBuilder.cs
@@ -8,7 +8,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Atmosphere
 {
-    static class CloudsBuilder
+    public static class CloudsBuilder
     {
         private static Shader _sphereShader = null;
         public static void Make(GameObject body, Sector sector, AtmosphereModule atmo, IModBehaviour mod)

--- a/NewHorizons/Builder/Atmosphere/CloudsBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/CloudsBuilder.cs
@@ -34,7 +34,7 @@ namespace NewHorizons.Builder.Atmosphere
 
             GameObject cloudsMainGO = new GameObject("Clouds");
             cloudsMainGO.SetActive(false);
-            cloudsMainGO.transform.parent = body.transform;
+            cloudsMainGO.transform.parent = sector?.transform ?? body.transform;
 
             GameObject cloudsTopGO = new GameObject("TopClouds");
             cloudsTopGO.SetActive(false);

--- a/NewHorizons/Builder/Atmosphere/EffectsBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/EffectsBuilder.cs
@@ -1,4 +1,5 @@
-﻿using NewHorizons.Utility;
+﻿using NewHorizons.External;
+using NewHorizons.Utility;
 using OWML.Utils;
 using UnityEngine;
 using Logger = NewHorizons.Utility.Logger;
@@ -7,11 +8,11 @@ namespace NewHorizons.Builder.Atmosphere
 {
     static class EffectsBuilder
     {
-        public static void Make(GameObject body, Sector sector, float surfaceSize, float atmoSize, bool hasRain, bool hasSnow)
+        public static void Make(GameObject body, Sector sector, AtmosphereModule.AirInfo info, float surfaceSize)
         {
             GameObject effectsGO = new GameObject("Effects");
             effectsGO.SetActive(false);
-            effectsGO.transform.parent = body.transform;
+            effectsGO.transform.parent = sector?.transform ?? body.transform;
             effectsGO.transform.localPosition = Vector3.zero;
 
             SectorCullGroup SCG = effectsGO.AddComponent<SectorCullGroup>();
@@ -21,7 +22,7 @@ namespace NewHorizons.Builder.Atmosphere
             SCG._dynamicCullingBounds = false;
             SCG._waitForStreaming = false;
 
-            if(hasRain)
+            if(info.IsRaining)
             {
                 var rainGO = GameObject.Instantiate(SearchUtilities.CachedFind("/GiantsDeep_Body/Sector_GD/Sector_GDInterior/Effects_GDInterior/Effects_GD_Rain"), effectsGO.transform);
                 rainGO.transform.localPosition = Vector3.zero;
@@ -31,7 +32,7 @@ namespace NewHorizons.Builder.Atmosphere
                 { 
                     new Keyframe(surfaceSize - 0.5f, 0),
                     new Keyframe(surfaceSize, 10f), 
-                    new Keyframe(atmoSize, 0f) 
+                    new Keyframe(info.Scale, 0f) 
                 });
 
                 rainGO.GetComponent<PlanetaryVectionController>()._activeInSector = sector;
@@ -39,7 +40,7 @@ namespace NewHorizons.Builder.Atmosphere
                 rainGO.SetActive(true);
             }
             
-            if(hasSnow)
+            if(info.IsSnowing)
             {
                 var snowGO = new GameObject("SnowEffects");
                 snowGO.transform.parent = effectsGO.transform;
@@ -55,7 +56,7 @@ namespace NewHorizons.Builder.Atmosphere
                     {
                         new Keyframe(surfaceSize - 0.5f, 0),
                         new Keyframe(surfaceSize, 10f),
-                        new Keyframe(atmoSize, 0f)
+                        new Keyframe(info.Scale, 0f)
                     });
 
                     snowEmitter.GetComponent<PlanetaryVectionController>()._activeInSector = sector;

--- a/NewHorizons/Builder/Atmosphere/EffectsBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/EffectsBuilder.cs
@@ -6,7 +6,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Atmosphere
 {
-    static class EffectsBuilder
+    public static class EffectsBuilder
     {
         public static void Make(GameObject body, Sector sector, AtmosphereModule.AirInfo info, float surfaceSize)
         {

--- a/NewHorizons/Builder/Atmosphere/FogBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/FogBuilder.cs
@@ -16,7 +16,7 @@ namespace NewHorizons.Builder.Atmosphere
         {
             GameObject fogGO = new GameObject("FogSphere");
             fogGO.SetActive(false);
-            fogGO.transform.parent = body.transform;
+            fogGO.transform.parent = sector?.transform ?? body.transform;
             fogGO.transform.localScale = Vector3.one;
 
             // Going to copy from dark bramble

--- a/NewHorizons/Builder/Atmosphere/FogBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/FogBuilder.cs
@@ -10,7 +10,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Atmosphere
 {
-    static class FogBuilder
+    public static class FogBuilder
     {
         public static void Make(GameObject body, Sector sector, AtmosphereModule atmo)
         {

--- a/NewHorizons/Builder/Atmosphere/SunOverrideBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/SunOverrideBuilder.cs
@@ -5,7 +5,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Atmosphere
 {
-    static class SunOverrideBuilder
+    public static class SunOverrideBuilder
     {
         public static void Make(GameObject body, Sector sector, AtmosphereModule atmo, float surfaceSize)
         {

--- a/NewHorizons/Builder/Atmosphere/SunOverrideBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/SunOverrideBuilder.cs
@@ -7,11 +7,11 @@ namespace NewHorizons.Builder.Atmosphere
 {
     static class SunOverrideBuilder
     {
-        public static void Make(GameObject body, Sector sector, float surfaceSize, AtmosphereModule atmo)
+        public static void Make(GameObject body, Sector sector, AtmosphereModule atmo, float surfaceSize)
         {
             GameObject overrideGO = new GameObject("SunOverride");
             overrideGO.SetActive(false);
-            overrideGO.transform.parent = body.transform;
+            overrideGO.transform.parent = sector?.transform ?? body.transform;
 
             GiantsDeepSunOverrideVolume GDSOV = overrideGO.AddComponent<GiantsDeepSunOverrideVolume>();
             GDSOV._sector = sector;

--- a/NewHorizons/Builder/Atmosphere/VolumesBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/VolumesBuilder.cs
@@ -8,7 +8,7 @@ namespace NewHorizons.Builder.Atmosphere
 {
     static class VolumesBuilder
     {
-        public static void Make(GameObject body, float innerRadius, float outerRadius, IPlanetConfig config)
+        public static void Make(GameObject body, float innerRadius, float outerRadius, bool useMiniMap)
         {
             GameObject volumesGO = new GameObject("Volumes");
             volumesGO.SetActive(false);
@@ -30,8 +30,8 @@ namespace NewHorizons.Builder.Atmosphere
             PlanetoidRuleset PR = rulesetGO.AddComponent<PlanetoidRuleset>();
             PR._altitudeFloor = innerRadius;
             PR._altitudeCeiling = outerRadius;
-            PR._useMinimap = !config.Base.IsSatellite;
-            PR._useAltimeter = !config.Base.IsSatellite;
+            PR._useMinimap = useMiniMap;
+            PR._useAltimeter = useMiniMap;
 
             EffectRuleset ER = rulesetGO.AddComponent<EffectRuleset>();
             ER._type = EffectRuleset.BubbleType.Underwater;

--- a/NewHorizons/Builder/Atmosphere/VolumesBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/VolumesBuilder.cs
@@ -6,7 +6,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Atmosphere
 {
-    static class VolumesBuilder
+    public static class VolumesBuilder
     {
         public static void Make(GameObject body, float innerRadius, float outerRadius, bool useMiniMap)
         {

--- a/NewHorizons/Builder/Body/AsteroidBeltBuilder.cs
+++ b/NewHorizons/Builder/Body/AsteroidBeltBuilder.cs
@@ -14,7 +14,7 @@ using NewHorizons.Handlers;
 
 namespace NewHorizons.Builder.Body
 {
-    static class AsteroidBeltBuilder
+    public static class AsteroidBeltBuilder
     {
         public static void Make(string bodyName, IPlanetConfig parentConfig, IModBehaviour mod)
         {

--- a/NewHorizons/Builder/Body/CloakBuilder.cs
+++ b/NewHorizons/Builder/Body/CloakBuilder.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace NewHorizons.Builder.Body
 {
-    static class CloakBuilder
+    public static class CloakBuilder
     {
         public static void Make(GameObject body, Sector sector, float radius)
         {

--- a/NewHorizons/Builder/Body/CometTailBuilder.cs
+++ b/NewHorizons/Builder/Body/CometTailBuilder.cs
@@ -12,9 +12,9 @@ namespace NewHorizons.Builder.Body
 {
     public static class CometTailBuilder
     {
-        public static void Make(GameObject go, IPlanetConfig config, AstroObject primary)
+        public static void Make(GameObject go, Sector sector, IPlanetConfig config, AstroObject primary)
         {
-            var cometTail = GameObject.Instantiate(GameObject.Find("Comet_Body/Sector_CO/Effects_CO/Effects_CO_TailMeshes"), go.transform);
+            var cometTail = GameObject.Instantiate(GameObject.Find("Comet_Body/Sector_CO/Effects_CO/Effects_CO_TailMeshes"), sector?.transform ?? go.transform);
             cometTail.transform.localPosition = Vector3.zero;
             cometTail.name = "CometTail";
             cometTail.transform.localScale = Vector3.one * config.Base.SurfaceSize / 110;

--- a/NewHorizons/Builder/Body/Geometry/Icosphere.cs
+++ b/NewHorizons/Builder/Body/Geometry/Icosphere.cs
@@ -8,7 +8,7 @@ using Random = UnityEngine.Random;
 
 namespace NewHorizons.Builder.Body.Geometry
 {
-    static class Icosphere
+    public static class Icosphere
     {
         private static readonly float t = (1f + Mathf.Sqrt(5f)) / 2f;
         // By subdivisions, will add to this to memoize computation of icospheres

--- a/NewHorizons/Builder/Body/GeometryBuilder.cs
+++ b/NewHorizons/Builder/Body/GeometryBuilder.cs
@@ -3,7 +3,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Body
 {
-    static class GeometryBuilder
+    public static class GeometryBuilder
     {
         public static void Make(GameObject body, Sector sector, float groundScale)
         {

--- a/NewHorizons/Builder/Body/GeometryBuilder.cs
+++ b/NewHorizons/Builder/Body/GeometryBuilder.cs
@@ -5,10 +5,10 @@ namespace NewHorizons.Builder.Body
 {
     static class GeometryBuilder
     {
-        public static void Make(GameObject body, float groundScale)
+        public static void Make(GameObject body, Sector sector, float groundScale)
         {
             GameObject groundGO = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-            groundGO.transform.parent = body.transform;
+            groundGO.transform.parent = sector?.transform ?? body.transform;
             groundGO.transform.localScale = new Vector3(groundScale, groundScale, groundScale);
             groundGO.transform.localPosition = Vector3.zero;
             groundGO.GetComponent<MeshFilter>().mesh = GameObject.Find("CloudsTopLayer_GD").GetComponent<MeshFilter>().mesh;

--- a/NewHorizons/Builder/Body/HeightMapBuilder.cs
+++ b/NewHorizons/Builder/Body/HeightMapBuilder.cs
@@ -13,7 +13,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Body
 {
-    static class HeightMapBuilder
+    public static class HeightMapBuilder
     {
         public static Shader PlanetShader;
 

--- a/NewHorizons/Builder/Body/HeightMapBuilder.cs
+++ b/NewHorizons/Builder/Body/HeightMapBuilder.cs
@@ -17,7 +17,7 @@ namespace NewHorizons.Builder.Body
     {
         public static Shader PlanetShader;
 
-        public static void Make(GameObject go, HeightMapModule module, IModBehaviour mod)
+        public static void Make(GameObject go, Sector sector, HeightMapModule module, IModBehaviour mod)
         {
             Texture2D heightMap, textureMap;
             try
@@ -35,7 +35,7 @@ namespace NewHorizons.Builder.Body
 
             GameObject cubeSphere = new GameObject("CubeSphere");
             cubeSphere.SetActive(false);
-            cubeSphere.transform.parent = go.transform;
+            cubeSphere.transform.parent = sector?.transform ?? go.transform;
             cubeSphere.transform.rotation = Quaternion.Euler(90, 0, 0);
 
             Mesh mesh = CubeSphere.Build(51, heightMap, module.MinHeight, module.MaxHeight, module.Stretch);

--- a/NewHorizons/Builder/Body/LavaBuilder.cs
+++ b/NewHorizons/Builder/Body/LavaBuilder.cs
@@ -12,7 +12,7 @@ namespace NewHorizons.Builder.Body
 {
     static class LavaBuilder
     {
-        public static void Make(GameObject body, Sector sector, OWRigidbody rb, LavaModule module) 
+        public static void Make(GameObject go, Sector sector, OWRigidbody rb, LavaModule module) 
         {
             var heightScale = module.Size;
             if(module.Curve != null)
@@ -27,7 +27,7 @@ namespace NewHorizons.Builder.Body
 
             var moltenCore = new GameObject("MoltenCore");
             moltenCore.SetActive(false);
-            moltenCore.transform.parent = body.transform;
+            moltenCore.transform.parent = sector?.transform ?? go.transform;
             moltenCore.transform.localPosition = Vector3.zero;
             moltenCore.transform.localScale = Vector3.one * module.Size;
 

--- a/NewHorizons/Builder/Body/LavaBuilder.cs
+++ b/NewHorizons/Builder/Body/LavaBuilder.cs
@@ -10,7 +10,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Body
 {
-    static class LavaBuilder
+    public static class LavaBuilder
     {
         public static void Make(GameObject go, Sector sector, OWRigidbody rb, LavaModule module) 
         {

--- a/NewHorizons/Builder/Body/ProcGenBuilder.cs
+++ b/NewHorizons/Builder/Body/ProcGenBuilder.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace NewHorizons.Builder.Body
 {
-    static class ProcGenBuilder
+    public static class ProcGenBuilder
     {
         public static void Make(GameObject go, Sector sector, ProcGenModule module)
         {

--- a/NewHorizons/Builder/Body/ProcGenBuilder.cs
+++ b/NewHorizons/Builder/Body/ProcGenBuilder.cs
@@ -11,10 +11,10 @@ namespace NewHorizons.Builder.Body
 {
     static class ProcGenBuilder
     {
-        public static void Make(GameObject go, ProcGenModule module)
+        public static void Make(GameObject go, Sector sector, ProcGenModule module)
         {
             GameObject icosphere = new GameObject("Icosphere");
-            icosphere.transform.parent = go.transform;
+            icosphere.transform.parent = sector?.transform ?? go.transform;
             icosphere.transform.rotation = Quaternion.Euler(90, 0, 0);
             icosphere.transform.localPosition = Vector3.zero;
 

--- a/NewHorizons/Builder/Body/RingBuilder.cs
+++ b/NewHorizons/Builder/Body/RingBuilder.cs
@@ -38,7 +38,7 @@ namespace NewHorizons.Builder.Body
             }
 
             var ringGO = new GameObject("Ring");
-            ringGO.transform.parent = sector.transform ?? body.transform;
+            ringGO.transform.parent = sector?.transform ?? body.transform;
             ringGO.transform.localPosition = Vector3.zero;
             ringGO.transform.localRotation = Quaternion.Euler(0, 0, 0);
             ringGO.transform.Rotate(ringGO.transform.TransformDirection(Vector3.up), ring.LongitudeOfAscendingNode);

--- a/NewHorizons/Builder/Body/RingBuilder.cs
+++ b/NewHorizons/Builder/Body/RingBuilder.cs
@@ -16,240 +16,240 @@ namespace NewHorizons.Builder.Body
 {
     static class RingBuilder
     {
-		public static Shader RingShader;
-		public static Shader RingShader1Pixel;
-		public static Shader UnlitRingShader;
-		public static Shader UnlitRingShader1Pixel;
+        public static Shader RingShader;
+        public static Shader RingShader1Pixel;
+        public static Shader UnlitRingShader;
+        public static Shader UnlitRingShader1Pixel;
 
-		public static GameObject Make(GameObject body, RingModule ring, IModBehaviour mod)
+        public static GameObject Make(GameObject body, Sector sector, RingModule ring, IModBehaviour mod)
         {
-			// Properly lit shader doesnt work yet
-			ring.Unlit = true;
+            // Properly lit shader doesnt work yet
+            ring.Unlit = true;
 
-			Texture2D ringTexture;
-			try
-			{
-				ringTexture = ImageUtilities.GetTexture(mod, ring.Texture);
-			}
-			catch (Exception e)
-			{
-				Logger.LogError($"Couldn't load Ring texture, {e.Message}, {e.StackTrace}");
-				return null;
-			}
+            Texture2D ringTexture;
+            try
+            {
+                ringTexture = ImageUtilities.GetTexture(mod, ring.Texture);
+            }
+            catch (Exception e)
+            {
+                Logger.LogError($"Couldn't load Ring texture, {e.Message}, {e.StackTrace}");
+                return null;
+            }
 
-			var ringGO = new GameObject("Ring");
-            ringGO.transform.parent = body.transform;
-			ringGO.transform.localPosition = Vector3.zero;
-			ringGO.transform.localRotation = Quaternion.Euler(0, 0, 0);
-			ringGO.transform.Rotate(ringGO.transform.TransformDirection(Vector3.up), ring.LongitudeOfAscendingNode);
-			ringGO.transform.Rotate(ringGO.transform.TransformDirection(Vector3.right), ring.Inclination);
+            var ringGO = new GameObject("Ring");
+            ringGO.transform.parent = sector.transform ?? body.transform;
+            ringGO.transform.localPosition = Vector3.zero;
+            ringGO.transform.localRotation = Quaternion.Euler(0, 0, 0);
+            ringGO.transform.Rotate(ringGO.transform.TransformDirection(Vector3.up), ring.LongitudeOfAscendingNode);
+            ringGO.transform.Rotate(ringGO.transform.TransformDirection(Vector3.right), ring.Inclination);
 
             var ringMF = ringGO.AddComponent<MeshFilter>();
             var ringMesh = ringMF.mesh;
             var ringMR = ringGO.AddComponent<MeshRenderer>();
-			var texture = ringTexture;
+            var texture = ringTexture;
 
-			if (RingShader == null) RingShader = Main.ShaderBundle.LoadAsset<Shader>("Assets/Shaders/Ring.shader");
-			if (UnlitRingShader == null) UnlitRingShader = Main.ShaderBundle.LoadAsset<Shader>("Assets/Shaders/UnlitTransparent.shader");
-			if (RingShader1Pixel == null) RingShader1Pixel = Main.ShaderBundle.LoadAsset<Shader>("Assets/Shaders/Ring1Pixel.shader");
-			if (UnlitRingShader1Pixel == null) UnlitRingShader1Pixel = Main.ShaderBundle.LoadAsset<Shader>("Assets/Shaders/UnlitRing1Pixel.shader");
+            if (RingShader == null) RingShader = Main.ShaderBundle.LoadAsset<Shader>("Assets/Shaders/Ring.shader");
+            if (UnlitRingShader == null) UnlitRingShader = Main.ShaderBundle.LoadAsset<Shader>("Assets/Shaders/UnlitTransparent.shader");
+            if (RingShader1Pixel == null) RingShader1Pixel = Main.ShaderBundle.LoadAsset<Shader>("Assets/Shaders/Ring1Pixel.shader");
+            if (UnlitRingShader1Pixel == null) UnlitRingShader1Pixel = Main.ShaderBundle.LoadAsset<Shader>("Assets/Shaders/UnlitRing1Pixel.shader");
 
-			var mat = new Material(ring.Unlit ? UnlitRingShader : RingShader);
-			if(texture.width == 1)
+            var mat = new Material(ring.Unlit ? UnlitRingShader : RingShader);
+            if (texture.width == 1)
             {
-				mat = new Material(ring.Unlit ? UnlitRingShader1Pixel : RingShader1Pixel);
-				mat.SetFloat("_InnerRadius", 0);
+                mat = new Material(ring.Unlit ? UnlitRingShader1Pixel : RingShader1Pixel);
+                mat.SetFloat("_InnerRadius", 0);
             }
-			ringMR.receiveShadows = !ring.Unlit;
+            ringMR.receiveShadows = !ring.Unlit;
 
-			mat.mainTexture = texture;
-			mat.renderQueue = 3000;
-			ringMR.material = mat;
+            mat.mainTexture = texture;
+            mat.renderQueue = 3000;
+            ringMR.material = mat;
 
-			// Make mesh
-			var segments = (int)Mathf.Clamp(ring.OuterRadius, 20, 2000);
-			BuildRingMesh(ringMesh, segments, ring.InnerRadius, ring.OuterRadius);
+            // Make mesh
+            var segments = (int)Mathf.Clamp(ring.OuterRadius, 20, 2000);
+            BuildRingMesh(ringMesh, segments, ring.InnerRadius, ring.OuterRadius);
 
-			if(ring.RotationSpeed != 0)
+            if (ring.RotationSpeed != 0)
             {
-				var rot = ringGO.AddComponent<RotateTransform>();
-				rot._degreesPerSecond = ring.RotationSpeed;
-				rot._localAxis = Vector3.down;
+                var rot = ringGO.AddComponent<RotateTransform>();
+                rot._degreesPerSecond = ring.RotationSpeed;
+                rot._localAxis = Vector3.down;
             }
 
-			// Funny collider thing
-			var ringVolume = new GameObject("RingVolume");
-			ringVolume.SetActive(false);
-			ringVolume.transform.parent = ringGO.transform;
-			ringVolume.transform.localPosition = Vector3.zero;
-			ringVolume.transform.localScale = Vector3.one;
-			ringVolume.transform.localRotation = Quaternion.identity;
-			ringVolume.layer = LayerMask.NameToLayer("BasicEffectVolume");
+            // Funny collider thing
+            var ringVolume = new GameObject("RingVolume");
+            ringVolume.SetActive(false);
+            ringVolume.transform.parent = ringGO.transform;
+            ringVolume.transform.localPosition = Vector3.zero;
+            ringVolume.transform.localScale = Vector3.one;
+            ringVolume.transform.localRotation = Quaternion.identity;
+            ringVolume.layer = LayerMask.NameToLayer("BasicEffectVolume");
 
-			var ringShape = ringVolume.AddComponent<RingShape>();
-			ringShape.innerRadius = ring.InnerRadius;
-			ringShape.outerRadius = ring.OuterRadius;
-			ringShape.height = 2f;
-			ringShape.center = Vector3.zero;
-			ringShape.SetCollisionMode(Shape.CollisionMode.Volume);
-			ringShape.SetLayer(Shape.Layer.Default);
-			ringShape.layerMask = -1;
-			ringShape.pointChecksOnly = true;
-			
-			var trigger = ringVolume.AddComponent<OWTriggerVolume>();
-			trigger._shape = ringShape;
+            var ringShape = ringVolume.AddComponent<RingShape>();
+            ringShape.innerRadius = ring.InnerRadius;
+            ringShape.outerRadius = ring.OuterRadius;
+            ringShape.height = 2f;
+            ringShape.center = Vector3.zero;
+            ringShape.SetCollisionMode(Shape.CollisionMode.Volume);
+            ringShape.SetLayer(Shape.Layer.Default);
+            ringShape.layerMask = -1;
+            ringShape.pointChecksOnly = true;
 
-			var sfv = ringVolume.AddComponent<SimpleFluidVolume>();
-			var fluidType = FluidVolume.Type.NONE;
+            var trigger = ringVolume.AddComponent<OWTriggerVolume>();
+            trigger._shape = ringShape;
 
-			if(!string.IsNullOrEmpty(ring.FluidType))
+            var sfv = ringVolume.AddComponent<SimpleFluidVolume>();
+            var fluidType = FluidVolume.Type.NONE;
+
+            if (!string.IsNullOrEmpty(ring.FluidType))
             {
-				try
-				{
-					fluidType = (FluidVolume.Type)Enum.Parse(typeof(FluidVolume.Type), ring.FluidType.ToUpper());
-				}
-				catch (Exception ex)
-				{
-					Logger.LogError($"Couldn't parse fluid volume type [{ring.FluidType}]: {ex.Message}, {ex.StackTrace}");
-				}
-			}
+                try
+                {
+                    fluidType = (FluidVolume.Type)Enum.Parse(typeof(FluidVolume.Type), ring.FluidType.ToUpper());
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError($"Couldn't parse fluid volume type [{ring.FluidType}]: {ex.Message}, {ex.StackTrace}");
+                }
+            }
 
-			sfv._fluidType = fluidType;
-			sfv._density = 1f;
+            sfv._fluidType = fluidType;
+            sfv._density = 1f;
 
-			ringVolume.SetActive(true);
+            ringVolume.SetActive(true);
 
-			if (ring.Curve != null)
-			{
-				var levelController = ringGO.AddComponent<SizeController>();
-				var curve = new AnimationCurve();
-				foreach (var pair in ring.Curve)
-				{
-					curve.AddKey(new Keyframe(pair.Time, pair.Value));
-				}
-				levelController.scaleCurve = curve;
-			}
+            if (ring.Curve != null)
+            {
+                var levelController = ringGO.AddComponent<SizeController>();
+                var curve = new AnimationCurve();
+                foreach (var pair in ring.Curve)
+                {
+                    curve.AddKey(new Keyframe(pair.Time, pair.Value));
+                }
+                levelController.scaleCurve = curve;
+            }
 
-			return ringGO;
-		}
+            return ringGO;
+        }
 
-		public static void BuildQuadMesh(Mesh mesh, float width)
+        public static void BuildQuadMesh(Mesh mesh, float width)
         {
-			Vector3[] vertices;
-			int[] tri;
-			Vector3[] normals;
-			Vector2[] uv;
+            Vector3[] vertices;
+            int[] tri;
+            Vector3[] normals;
+            Vector2[] uv;
 
-			vertices = new Vector3[4];
-			tri = new int[6];
-			normals = new Vector3[4];
-			uv = new Vector2[4];
+            vertices = new Vector3[4];
+            tri = new int[6];
+            normals = new Vector3[4];
+            uv = new Vector2[4];
 
-			vertices[0] = new Vector3(-width / 2, 0, -width / 2);
-			vertices[1] = new Vector3(width / 2, 0, -width / 2);
-			vertices[2] = new Vector3(-width / 2, 0, width / 2);
-			vertices[3] = new Vector3(width / 2, 0, width / 2);
+            vertices[0] = new Vector3(-width / 2, 0, -width / 2);
+            vertices[1] = new Vector3(width / 2, 0, -width / 2);
+            vertices[2] = new Vector3(-width / 2, 0, width / 2);
+            vertices[3] = new Vector3(width / 2, 0, width / 2);
 
-			tri[0] = 0;
-			tri[1] = 2;
-			tri[2] = 1;
+            tri[0] = 0;
+            tri[1] = 2;
+            tri[2] = 1;
 
-			tri[3] = 2;
-			tri[4] = 3;
-			tri[5] = 1;
+            tri[3] = 2;
+            tri[4] = 3;
+            tri[5] = 1;
 
-			normals[0] = Vector3.up;
-			normals[1] = Vector3.up;
-			normals[2] = Vector3.up;
-			normals[3] = Vector3.up;
+            normals[0] = Vector3.up;
+            normals[1] = Vector3.up;
+            normals[2] = Vector3.up;
+            normals[3] = Vector3.up;
 
-			uv[0] = new Vector2(0, 0);
-			uv[1] = new Vector2(1, 0);
-			uv[2] = new Vector2(0, 1);
-			uv[3] = new Vector2(1, 1);
+            uv[0] = new Vector2(0, 0);
+            uv[1] = new Vector2(1, 0);
+            uv[2] = new Vector2(0, 1);
+            uv[3] = new Vector2(1, 1);
 
-			mesh.vertices = vertices;
-			mesh.triangles = tri;
-			mesh.normals = normals;
-			mesh.uv = uv;
-		}
+            mesh.vertices = vertices;
+            mesh.triangles = tri;
+            mesh.normals = normals;
+            mesh.uv = uv;
+        }
 
-		// Thank you https://github.com/boardtobits/planet-ring-mesh/blob/master/PlanetRing.cs
-		public static void BuildRingMesh(Mesh ringMesh, int segments, float innerRadius, float outerRadius)
+        // Thank you https://github.com/boardtobits/planet-ring-mesh/blob/master/PlanetRing.cs
+        public static void BuildRingMesh(Mesh ringMesh, int segments, float innerRadius, float outerRadius)
         {
-			Vector3[] vertices = new Vector3[(segments + 1) * 2 * 2];
-			int[] triangles = new int[segments * 6 * 2];
-			Vector2[] uv = new Vector2[(segments + 1) * 2 * 2];
-			int halfway = (segments + 1) * 2;
+            Vector3[] vertices = new Vector3[(segments + 1) * 2 * 2];
+            int[] triangles = new int[segments * 6 * 2];
+            Vector2[] uv = new Vector2[(segments + 1) * 2 * 2];
+            int halfway = (segments + 1) * 2;
 
-			for (int i = 0; i < segments + 1; i++)
-			{
-				float progress = (float)i / (float)segments;
-				float angle = progress * 2 * Mathf.PI;
-				float x = Mathf.Sin(angle);
-				float z = Mathf.Cos(angle);
+            for (int i = 0; i < segments + 1; i++)
+            {
+                float progress = (float)i / (float)segments;
+                float angle = progress * 2 * Mathf.PI;
+                float x = Mathf.Sin(angle);
+                float z = Mathf.Cos(angle);
 
-				vertices[i * 2] = vertices[i * 2 + halfway] = new Vector3(x, 0f, z) * outerRadius;
-				vertices[i * 2 + 1] = vertices[i * 2 + 1 + halfway] = new Vector3(x, 0f, z) * innerRadius;
-				//uv[i * 2] = uv[i * 2 + halfway] = new Vector2(progress, 0f);
-				//uv[i * 2 + 1] = uv[i * 2 + 1 + halfway] = new Vector2(progress, 1f);	  				
-				uv[i * 2] = uv[i * 2 + halfway] = (new Vector2(x, z) / 2f) + Vector2.one * 0.5f;
-				uv[i * 2 + 1] = uv[i * 2 + 1 + halfway] = new Vector2(0.5f, 0.5f);
+                vertices[i * 2] = vertices[i * 2 + halfway] = new Vector3(x, 0f, z) * outerRadius;
+                vertices[i * 2 + 1] = vertices[i * 2 + 1 + halfway] = new Vector3(x, 0f, z) * innerRadius;
+                //uv[i * 2] = uv[i * 2 + halfway] = new Vector2(progress, 0f);
+                //uv[i * 2 + 1] = uv[i * 2 + 1 + halfway] = new Vector2(progress, 1f);	  				
+                uv[i * 2] = uv[i * 2 + halfway] = (new Vector2(x, z) / 2f) + Vector2.one * 0.5f;
+                uv[i * 2 + 1] = uv[i * 2 + 1 + halfway] = new Vector2(0.5f, 0.5f);
 
-				if (i != segments)
-				{
-					triangles[i * 12] = i * 2;
-					triangles[i * 12 + 1] = triangles[i * 12 + 4] = (i + 1) * 2;
-					triangles[i * 12 + 2] = triangles[i * 12 + 3] = i * 2 + 1;
-					triangles[i * 12 + 5] = (i + 1) * 2 + 1;
+                if (i != segments)
+                {
+                    triangles[i * 12] = i * 2;
+                    triangles[i * 12 + 1] = triangles[i * 12 + 4] = (i + 1) * 2;
+                    triangles[i * 12 + 2] = triangles[i * 12 + 3] = i * 2 + 1;
+                    triangles[i * 12 + 5] = (i + 1) * 2 + 1;
 
-					triangles[i * 12 + 6] = i * 2 + halfway;
-					triangles[i * 12 + 7] = triangles[i * 12 + 10] = i * 2 + 1 + halfway;
-					triangles[i * 12 + 8] = triangles[i * 12 + 9] = (i + 1) * 2 + halfway;
-					triangles[i * 12 + 11] = (i + 1) * 2 + 1 + halfway;
-				}
+                    triangles[i * 12 + 6] = i * 2 + halfway;
+                    triangles[i * 12 + 7] = triangles[i * 12 + 10] = i * 2 + 1 + halfway;
+                    triangles[i * 12 + 8] = triangles[i * 12 + 9] = (i + 1) * 2 + halfway;
+                    triangles[i * 12 + 11] = (i + 1) * 2 + 1 + halfway;
+                }
 
-			}
+            }
 
-			ringMesh.vertices = vertices;
-			ringMesh.triangles = triangles;
-			ringMesh.uv = uv;
-			ringMesh.RecalculateNormals();
-		}
+            ringMesh.vertices = vertices;
+            ringMesh.triangles = triangles;
+            ringMesh.uv = uv;
+            ringMesh.RecalculateNormals();
+        }
 
-		public static void BuildCircleMesh(Mesh mesh, int segments, float outerRadius)
-		{
-			float angleStep = 360.0f / (float)segments;
-			List<Vector3> vertexList = new List<Vector3>();
-			List<int> triangleList = new List<int>();
-			List<Vector2> uv = new List<Vector2>();
-			Quaternion quaternion = Quaternion.Euler(0.0f, angleStep, 0f);
-			// Make first triangle.
-			vertexList.Add(new Vector3(0.0f, 0.0f, 0.0f));  // 1. Circle center.
-			vertexList.Add(new Vector3(0.0f, 0f, outerRadius));  // 2. First vertex on circle outline (radius = 0.5f)
-			vertexList.Add(quaternion * vertexList[1]);     // 3. First vertex on circle outline rotated by angle)
-															// Add triangle indices.
-			uv.Add(new Vector2(0.5f, 0.5f));
-			uv.Add(new Vector2(0.5f, 1f));
-			uv.Add(quaternion * uv[1]);
+        public static void BuildCircleMesh(Mesh mesh, int segments, float outerRadius)
+        {
+            float angleStep = 360.0f / (float)segments;
+            List<Vector3> vertexList = new List<Vector3>();
+            List<int> triangleList = new List<int>();
+            List<Vector2> uv = new List<Vector2>();
+            Quaternion quaternion = Quaternion.Euler(0.0f, angleStep, 0f);
+            // Make first triangle.
+            vertexList.Add(new Vector3(0.0f, 0.0f, 0.0f));  // 1. Circle center.
+            vertexList.Add(new Vector3(0.0f, 0f, outerRadius));  // 2. First vertex on circle outline (radius = 0.5f)
+            vertexList.Add(quaternion * vertexList[1]);     // 3. First vertex on circle outline rotated by angle)
+                                                            // Add triangle indices.
+            uv.Add(new Vector2(0.5f, 0.5f));
+            uv.Add(new Vector2(0.5f, 1f));
+            uv.Add(quaternion * uv[1]);
 
-			triangleList.Add(0);
-			triangleList.Add(1);
-			triangleList.Add(2);
-			for (int i = 0; i < segments - 1; i++)
-			{
-				triangleList.Add(0);                      // Index of circle center.
-				triangleList.Add(vertexList.Count - 1);
-				triangleList.Add(vertexList.Count);
-				vertexList.Add(quaternion * vertexList[vertexList.Count - 1]);
-				uv.Add(quaternion * (uv[uv.Count - 1] - Vector2.one * 0.5f) + Vector3.one * 0.5f);
-			}
+            triangleList.Add(0);
+            triangleList.Add(1);
+            triangleList.Add(2);
+            for (int i = 0; i < segments - 1; i++)
+            {
+                triangleList.Add(0);                      // Index of circle center.
+                triangleList.Add(vertexList.Count - 1);
+                triangleList.Add(vertexList.Count);
+                vertexList.Add(quaternion * vertexList[vertexList.Count - 1]);
+                uv.Add(quaternion * (uv[uv.Count - 1] - Vector2.one * 0.5f) + Vector3.one * 0.5f);
+            }
 
-			mesh.vertices = vertexList.ToArray();
-			mesh.triangles = triangleList.ToArray();
-			mesh.uv = uv.ToArray();
-			mesh.RecalculateNormals();
+            mesh.vertices = vertexList.ToArray();
+            mesh.triangles = triangleList.ToArray();
+            mesh.uv = uv.ToArray();
+            mesh.RecalculateNormals();
 
-		}
-	}
+        }
+    }
 }

--- a/NewHorizons/Builder/Body/RingBuilder.cs
+++ b/NewHorizons/Builder/Body/RingBuilder.cs
@@ -14,7 +14,7 @@ using NewHorizons.Components.SizeControllers;
 
 namespace NewHorizons.Builder.Body
 {
-    static class RingBuilder
+    public static class RingBuilder
     {
         public static Shader RingShader;
         public static Shader RingShader1Pixel;

--- a/NewHorizons/Builder/Body/SandBuilder.cs
+++ b/NewHorizons/Builder/Body/SandBuilder.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace NewHorizons.Builder.Body
 {
-    static class SandBuilder
+    public static class SandBuilder
     {
         public static void Make(GameObject go, Sector sector, OWRigidbody rb, SandModule module)
         {

--- a/NewHorizons/Builder/Body/SandBuilder.cs
+++ b/NewHorizons/Builder/Body/SandBuilder.cs
@@ -17,7 +17,7 @@ namespace NewHorizons.Builder.Body
             sandGO.SetActive(false);
 
             var sandSphere = GameObject.Instantiate(GameObject.Find("TowerTwin_Body/SandSphere_Draining/SandSphere"), sandGO.transform);
-            if(module.Tint != null)
+            if (module.Tint != null)
             {
                 var oldMR = sandSphere.GetComponent<TessellatedSphereRenderer>();
                 var sandMaterials = oldMR.sharedMaterials;
@@ -38,25 +38,25 @@ namespace NewHorizons.Builder.Body
             collider.SetActive(true);
 
             var occlusionSphere = GameObject.Instantiate(GameObject.Find("TowerTwin_Body/SandSphere_Draining/OcclusionSphere"), sandGO.transform);
-            
+
             var proxyShadowCasterGO = GameObject.Instantiate(GameObject.Find("TowerTwin_Body/SandSphere_Draining/ProxyShadowCaster"), sandGO.transform);
             var proxyShadowCaster = proxyShadowCasterGO.GetComponent<ProxyShadowCaster>();
             proxyShadowCaster.SetSuperGroup(sandGO.GetComponent<ProxyShadowCasterSuperGroup>());
 
             sandSphere.AddComponent<ChildColliderSettings>();
 
-            if(module.Curve != null)
+            if (module.Curve != null)
             {
                 var levelController = sandGO.AddComponent<SandLevelController>();
                 var curve = new AnimationCurve();
-                foreach(var pair in module.Curve)
+                foreach (var pair in module.Curve)
                 {
                     curve.AddKey(new Keyframe(pair.Time, 2f * module.Size * pair.Value));
                 }
                 levelController._scaleCurve = curve;
             }
 
-            sandGO.transform.parent = go.transform;
+            sandGO.transform.parent = sector?.transform ?? go.transform;
             sandGO.transform.localPosition = Vector3.zero;
             sandGO.transform.localScale = Vector3.one * module.Size * 2f;
 

--- a/NewHorizons/Builder/Body/SingularityBuilder.cs
+++ b/NewHorizons/Builder/Body/SingularityBuilder.cs
@@ -47,6 +47,8 @@ namespace NewHorizons.Builder.Body
             bool isWormHole = config.Singularity?.TargetStarSystem != null;
             bool hasHazardVolume = !isWormHole && (pairedSingularity == null);
 
+            bool makeZeroGVolume = config.Singularity == null ? true : config.Singularity.MakeZeroGVolume;
+
             Vector3 localPosition = config.Singularity?.Position == null ? Vector3.zero : (Vector3)config.Singularity.Position;
 
             GameObject newSingularity = null;
@@ -56,7 +58,7 @@ namespace NewHorizons.Builder.Body
                     newSingularity = MakeBlackHole(go, sector, localPosition, size, hasHazardVolume, config.Singularity.TargetStarSystem);
                     break;
                 case Polarity.WhiteHole:
-                    newSingularity = MakeWhiteHole(go, sector, OWRB, localPosition, size);
+                    newSingularity = MakeWhiteHole(go, sector, OWRB, localPosition, size, makeZeroGVolume);
                     break;
             }
 

--- a/NewHorizons/Builder/Body/SingularityBuilder.cs
+++ b/NewHorizons/Builder/Body/SingularityBuilder.cs
@@ -12,7 +12,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Body
 {
-    static class SingularityBuilder
+    public static class SingularityBuilder
     {
         enum Polarity
         {

--- a/NewHorizons/Builder/Body/SingularityBuilder.cs
+++ b/NewHorizons/Builder/Body/SingularityBuilder.cs
@@ -23,14 +23,14 @@ namespace NewHorizons.Builder.Body
         private static Shader blackHoleShader = null;
         private static Shader whiteHoleShader = null;
 
-        public static void Make(GameObject body, Sector sector, OWRigidbody OWRB, IPlanetConfig config)
+        public static void Make(GameObject go, Sector sector, OWRigidbody OWRB, IPlanetConfig config)
         {
             // Backwards compatibility
             if(config.Singularity == null)
             {
                 if(config.Base.BlackHoleSize != 0)
                 {
-                    MakeBlackHole(body, sector, Vector3.zero, config.Base.BlackHoleSize, true, null);
+                    MakeBlackHole(go, sector, Vector3.zero, config.Base.BlackHoleSize, true, null);
                 }
                 return;
             }
@@ -53,10 +53,10 @@ namespace NewHorizons.Builder.Body
             switch (polarity)
             {
                 case Polarity.BlackHole:
-                    newSingularity = MakeBlackHole(body, sector, localPosition, size, hasHazardVolume, config.Singularity.TargetStarSystem);
+                    newSingularity = MakeBlackHole(go, sector, localPosition, size, hasHazardVolume, config.Singularity.TargetStarSystem);
                     break;
                 case Polarity.WhiteHole:
-                    newSingularity = MakeWhiteHole(body, sector, OWRB, localPosition, size);
+                    newSingularity = MakeWhiteHole(go, sector, OWRB, localPosition, size);
                     break;
             }
 
@@ -92,11 +92,11 @@ namespace NewHorizons.Builder.Body
             }
         }
 
-        public static GameObject MakeBlackHole(GameObject body, Sector sector, Vector3 localPosition, float size, bool hasDestructionVolume, string targetSolarSystem, bool makeAudio = true)
+        public static GameObject MakeBlackHole(GameObject go, Sector sector, Vector3 localPosition, float size, bool hasDestructionVolume, string targetSolarSystem, bool makeAudio = true)
         {
             var blackHole = new GameObject("BlackHole");
             blackHole.SetActive(false);
-            blackHole.transform.parent = body.transform;
+            blackHole.transform.parent = sector?.transform ?? go.transform;
             blackHole.transform.localPosition = localPosition;
 
             var blackHoleRender = new GameObject("BlackHoleRender");
@@ -167,7 +167,7 @@ namespace NewHorizons.Builder.Body
         {
             var whiteHole = new GameObject("WhiteHole");
             whiteHole.SetActive(false);
-            whiteHole.transform.parent = body.transform;
+            whiteHole.transform.parent = sector?.transform ?? body.transform;
             whiteHole.transform.localPosition = localPosition;
 
             var whiteHoleRenderer = new GameObject("WhiteHoleRenderer");

--- a/NewHorizons/Builder/Body/StarBuilder.cs
+++ b/NewHorizons/Builder/Body/StarBuilder.cs
@@ -17,14 +17,14 @@ namespace NewHorizons.Builder.Body
     static class StarBuilder
     {
         public const float OuterRadiusRatio = 1.5f;
-
         private static Texture2D _colorOverTime;
-        public static StarController Make(GameObject body, Sector sector, StarModule starModule)
+
+        public static StarController Make(GameObject go, Sector sector, StarModule starModule)
         {
             if (_colorOverTime == null) _colorOverTime = ImageUtilities.GetTexture(Main.Instance, "AssetBundle/StarColorOverTime.png");
 
             var starGO = new GameObject("Star");
-            starGO.transform.parent = body.transform;
+            starGO.transform.parent = sector?.transform ?? go.transform;
 
             var sunSurface = GameObject.Instantiate(GameObject.Find("Sun_Body/Sector_SUN/Geometry_SUN/Surface"), starGO.transform);
             sunSurface.transform.localPosition = Vector3.zero;
@@ -67,7 +67,7 @@ namespace NewHorizons.Builder.Body
 
             if(starModule.HasAtmosphere)
             {
-                var sunAtmosphere = GameObject.Instantiate(GameObject.Find("Sun_Body/Atmosphere_SUN"), body.transform);
+                var sunAtmosphere = GameObject.Instantiate(GameObject.Find("Sun_Body/Atmosphere_SUN"), go.transform);
                 sunAtmosphere.transform.localPosition = Vector3.zero;
                 sunAtmosphere.transform.localScale = Vector3.one;
                 sunAtmosphere.name = "Atmosphere_Star";
@@ -157,7 +157,7 @@ namespace NewHorizons.Builder.Body
             StarController starController = null;
             if (starModule.SolarLuminosity != 0)
             {
-                starController = body.AddComponent<StarController>();
+                starController = go.AddComponent<StarController>();
                 starController.Light = light;
                 starController.AmbientLight = ambientLight;
                 starController.FaceActiveCamera = faceActiveCamera;

--- a/NewHorizons/Builder/Body/StarBuilder.cs
+++ b/NewHorizons/Builder/Body/StarBuilder.cs
@@ -14,7 +14,7 @@ using NewHorizons.Components.SizeControllers;
 
 namespace NewHorizons.Builder.Body
 {
-    static class StarBuilder
+    public static class StarBuilder
     {
         public const float OuterRadiusRatio = 1.5f;
         private static Texture2D _colorOverTime;

--- a/NewHorizons/Builder/Body/WaterBuilder.cs
+++ b/NewHorizons/Builder/Body/WaterBuilder.cs
@@ -11,14 +11,14 @@ namespace NewHorizons.Builder.Body
 {
     static class WaterBuilder
     {
-        public static void Make(GameObject body, Sector sector, OWRigidbody rb, WaterModule module)
+        public static void Make(GameObject go, Sector sector, OWRigidbody rb, WaterModule module)
         {
             var waterSize = module.Size;
 
             GameObject waterGO = new GameObject("Water");
             waterGO.SetActive(false);
             waterGO.layer = 15;
-            waterGO.transform.parent = body.transform;
+            waterGO.transform.parent = sector?.transform ?? go.transform;
             waterGO.transform.localScale = new Vector3(waterSize, waterSize, waterSize);
 
             var GDTSR = GameObject.Find("Ocean_GD").GetComponent<TessellatedSphereRenderer>();

--- a/NewHorizons/Builder/Body/WaterBuilder.cs
+++ b/NewHorizons/Builder/Body/WaterBuilder.cs
@@ -9,7 +9,7 @@ using NewHorizons.Components.SizeControllers;
 
 namespace NewHorizons.Builder.Body
 {
-    static class WaterBuilder
+    public static class WaterBuilder
     {
         public static void Make(GameObject go, Sector sector, OWRigidbody rb, WaterModule module)
         {

--- a/NewHorizons/Builder/General/AmbientLightBuilder.cs
+++ b/NewHorizons/Builder/General/AmbientLightBuilder.cs
@@ -6,7 +6,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.General
 {
-    static class AmbientLightBuilder
+    public static class AmbientLightBuilder
     {
         public static void Make(GameObject body, Sector sector, float scale)
         {

--- a/NewHorizons/Builder/General/AmbientLightBuilder.cs
+++ b/NewHorizons/Builder/General/AmbientLightBuilder.cs
@@ -8,9 +8,9 @@ namespace NewHorizons.Builder.General
 {
     static class AmbientLightBuilder
     {
-        public static void Make(GameObject body, float scale)
+        public static void Make(GameObject body, Sector sector, float scale)
         {
-            GameObject lightGO = GameObject.Instantiate(GameObject.Find("BrittleHollow_Body/AmbientLight_BH_Surface"), body.transform);
+            GameObject lightGO = GameObject.Instantiate(GameObject.Find("BrittleHollow_Body/AmbientLight_BH_Surface"), sector?.transform ?? body.transform);
             lightGO.transform.localPosition = Vector3.zero;
             lightGO.name = "Light";
 

--- a/NewHorizons/Builder/General/AstroObjectBuilder.cs
+++ b/NewHorizons/Builder/General/AstroObjectBuilder.cs
@@ -9,7 +9,7 @@ using NewHorizons.Components.Orbital;
 
 namespace NewHorizons.Builder.General
 {
-    static class AstroObjectBuilder
+    public static class AstroObjectBuilder
     {
         public static NHAstroObject Make(GameObject body, AstroObject primaryBody, IPlanetConfig config)
         {

--- a/NewHorizons/Builder/General/DetectorBuilder.cs
+++ b/NewHorizons/Builder/General/DetectorBuilder.cs
@@ -12,7 +12,7 @@ using NewHorizons.External.Configs;
 
 namespace NewHorizons.Builder.General
 {
-    static class DetectorBuilder
+    public static class DetectorBuilder
     {
         public static GameObject Make(GameObject body, OWRigidbody OWRB, AstroObject primaryBody, AstroObject astroObject, IPlanetConfig config)
         {

--- a/NewHorizons/Builder/General/GravityBuilder.cs
+++ b/NewHorizons/Builder/General/GravityBuilder.cs
@@ -9,7 +9,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.General
 {
-    static class GravityBuilder
+    public static class GravityBuilder
     {
         public static GravityVolume Make(GameObject body, AstroObject ao, IPlanetConfig config)
         {

--- a/NewHorizons/Builder/General/RFVolumeBuilder.cs
+++ b/NewHorizons/Builder/General/RFVolumeBuilder.cs
@@ -5,7 +5,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.General
 {
-    static class RFVolumeBuilder
+    public static class RFVolumeBuilder
     {
         public static void Make(GameObject body, OWRigidbody rigidbody, float sphereOfInfluence)
         {

--- a/NewHorizons/Builder/General/SectorBuilder.cs
+++ b/NewHorizons/Builder/General/SectorBuilder.cs
@@ -6,7 +6,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.General
 {
-    static class MakeSector
+    public static class MakeSector
     {
         public static Sector Make(GameObject body, OWRigidbody rigidbody, float sphereOfInfluence)
         {

--- a/NewHorizons/Builder/General/SpawnPointBuilder.cs
+++ b/NewHorizons/Builder/General/SpawnPointBuilder.cs
@@ -7,7 +7,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.General
 {
-    static class SpawnPointBuilder
+    public static class SpawnPointBuilder
     {
         private static bool suitUpQueued = false;
         public static SpawnPoint Make(GameObject body, SpawnModule module, OWRigidbody rb)

--- a/NewHorizons/Builder/Orbital/FocalPointBuilder.cs
+++ b/NewHorizons/Builder/Orbital/FocalPointBuilder.cs
@@ -15,7 +15,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.Orbital
 {
-    static class FocalPointBuilder
+    public static class FocalPointBuilder
     {
         public static void Make(GameObject go, AstroObject ao, IPlanetConfig config, IModBehaviour mod)
         {

--- a/NewHorizons/Builder/Orbital/InitialMotionBuilder.cs
+++ b/NewHorizons/Builder/Orbital/InitialMotionBuilder.cs
@@ -13,7 +13,7 @@ using NewHorizons.Components.Orbital;
 
 namespace NewHorizons.Builder.Orbital
 {
-    static class InitialMotionBuilder
+    public static class InitialMotionBuilder
     {
         public static InitialMotion Make(GameObject body, AstroObject primaryBody, AstroObject secondaryBody, OWRigidbody OWRB, OrbitModule orbit)
         {

--- a/NewHorizons/Builder/Orbital/InitialMotionBuilder.cs
+++ b/NewHorizons/Builder/Orbital/InitialMotionBuilder.cs
@@ -73,12 +73,12 @@ namespace NewHorizons.Builder.Orbital
                 {
                     // It's a circumbinary moon/planet
                     var fakePrimaryBody = focalPoint.FakeMassBody.GetComponent<AstroObject>();
-                    SetMotionFromPrimary(fakePrimaryBody, secondaryBody as NHAstroObject, initialMotion);
+                    SetMotionFromPrimary(fakePrimaryBody, secondaryBody, secondaryBody as NHAstroObject, initialMotion);
                 }
             }
             else if (primaryBody.GetGravityVolume())
             {
-                SetMotionFromPrimary(primaryBody, secondaryBody as NHAstroObject, initialMotion);
+                SetMotionFromPrimary(primaryBody, secondaryBody, secondaryBody as NHAstroObject, initialMotion);
             }
             else
             {
@@ -86,13 +86,13 @@ namespace NewHorizons.Builder.Orbital
             }
         }
 
-        private static void SetMotionFromPrimary(AstroObject primaryBody, NHAstroObject secondaryBody, InitialMotion initialMotion)
+        public static void SetMotionFromPrimary(AstroObject primaryBody, AstroObject secondaryBody, IOrbitalParameters orbit, InitialMotion initialMotion)
         {
             initialMotion.SetPrimaryBody(primaryBody.GetAttachedOWRigidbody());
 
             var primaryGravity = new Gravity(primaryBody.GetGravityVolume());
             var secondaryGravity = new Gravity(secondaryBody.GetGravityVolume());
-            var velocity = secondaryBody.GetOrbitalParameters(primaryGravity, secondaryGravity).InitialVelocity;
+            var velocity = orbit.GetOrbitalParameters(primaryGravity, secondaryGravity).InitialVelocity;
 
             var parentVelocity = primaryBody?.GetComponent<InitialMotion>()?.GetInitVelocity() ?? Vector3.zero;
             initialMotion._cachedInitVelocity = velocity + parentVelocity;

--- a/NewHorizons/Builder/Orbital/OrbitlineBuilder.cs
+++ b/NewHorizons/Builder/Orbital/OrbitlineBuilder.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace NewHorizons.Builder.Orbital
 {
-    static class OrbitlineBuilder
+    public static class OrbitlineBuilder
     {
         public static OrbitLine Make(GameObject body, NHAstroObject astroObject, bool isMoon, IPlanetConfig config)
         {

--- a/NewHorizons/Builder/Props/GeyserBuilder.cs
+++ b/NewHorizons/Builder/Props/GeyserBuilder.cs
@@ -15,7 +15,7 @@ namespace NewHorizons.Builder.Props
         {
             var original = GameObject.Find("TimberHearth_Body/Sector_TH/Interactables_TH/Geysers/Geyser_Village");
             GameObject geyserGO = original.InstantiateInactive();
-            geyserGO.transform.parent = sector.transform;
+            geyserGO.transform.parent = sector?.transform ?? go.transform;
             geyserGO.name = "Geyser";
 
             var pos = ((Vector3)info.position);

--- a/NewHorizons/Builder/Props/NomaiTextBuilder.cs
+++ b/NewHorizons/Builder/Props/NomaiTextBuilder.cs
@@ -161,6 +161,7 @@ namespace NewHorizons.Builder.Props
                 computerObject.transform.localPosition = info?.position ?? Vector3.zero;
 
                 var up = computerObject.transform.position - go.transform.position;
+                if (info.normal != null) up = go.transform.TransformDirection(info.normal);
                 computerObject.transform.rotation = Quaternion.FromToRotation(Vector3.up, up) * computerObject.transform.rotation;
 
                 var computer = computerObject.GetComponent<NomaiComputer>();

--- a/NewHorizons/Builder/Props/NomaiTextBuilder.cs
+++ b/NewHorizons/Builder/Props/NomaiTextBuilder.cs
@@ -92,7 +92,7 @@ namespace NewHorizons.Builder.Props
                     nomaiWallTextObj.transform.up = up;
                     nomaiWallTextObj.transform.forward = forward;
                 }
-                if(info.rotation != null)
+                if (info.rotation != null)
                 {
                     nomaiWallTextObj.transform.localRotation = Quaternion.Euler(info.rotation);
                 }
@@ -312,7 +312,7 @@ namespace NewHorizons.Builder.Props
                 {
                     arc = _childArcPrefabs[Random.Range(0, _childArcPrefabs.Count())].InstantiateInactive();
                 }
-                else if(type == "stranger" && _ghostArcPrefabs.Count() > 0) // It could be empty if they dont have the DLC
+                else if (type == "stranger" && _ghostArcPrefabs.Count() > 0) // It could be empty if they dont have the DLC
                 {
                     arc = _ghostArcPrefabs[Random.Range(0, _ghostArcPrefabs.Count())].InstantiateInactive();
                 }

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -25,7 +25,7 @@ namespace NewHorizons.Builder.Props
         }
 
         private static void MakeSlideReel(GameObject go, Sector sector, PropModule.ProjectionInfo info, IModBehaviour mod)
-        { 
+        {
             if (_slideReelPrefab == null)
             {
                 _slideReelPrefab = GameObject.Find("RingWorld_Body/Sector_RingInterior/Sector_Zone1/Sector_SlideBurningRoom_Zone1/Interactables_SlideBurningRoom_Zone1/Prefab_IP_SecretAlcove/RotationPivot/SlideReelSocket/Prefab_IP_Reel_1_LibraryPath")?.gameObject?.InstantiateInactive();
@@ -46,7 +46,7 @@ namespace NewHorizons.Builder.Props
 
             var slideCollectionContainer = slideReelObj.GetRequiredComponent<SlideCollectionContainer>();
 
-            foreach(var renderer in slideReelObj.GetComponentsInChildren<Renderer>())
+            foreach (var renderer in slideReelObj.GetComponentsInChildren<Renderer>())
             {
                 renderer.enabled = true;
             }
@@ -62,7 +62,7 @@ namespace NewHorizons.Builder.Props
             // The base game ones only have 15 slides max
             var textures = new Texture2D[slidesCount >= 15 ? 15 : slidesCount];
 
-            for(int i = 0; i < slidesCount; i++)
+            for (int i = 0; i < slidesCount; i++)
             {
                 var slide = new Slide();
                 var slideInfo = info.slides[i];
@@ -71,7 +71,7 @@ namespace NewHorizons.Builder.Props
                 slide.textureOverride = ImageUtilities.Invert(texture);
 
                 // Track the first 15 to put on the slide reel object
-                if(i < 15) textures[i] = texture;
+                if (i < 15) textures[i] = texture;
 
                 AddModules(slideInfo, ref slide);
 

--- a/NewHorizons/Builder/Props/RaftBuilder.cs
+++ b/NewHorizons/Builder/Props/RaftBuilder.cs
@@ -20,7 +20,7 @@ namespace NewHorizons.Builder.Props
 
         public static void Make(GameObject planetGO, Sector sector, PropModule.RaftInfo info, OWRigidbody planetBody)
         {
-            if(_prefab == null)
+            if (_prefab == null)
             {
                 _prefab = GameObject.FindObjectOfType<RaftController>()?.gameObject?.InstantiateInactive();
                 if (_prefab == null)
@@ -33,7 +33,7 @@ namespace NewHorizons.Builder.Props
 
             GameObject raftObject = _prefab.InstantiateInactive();
             raftObject.name = "Raft_Body";
-            raftObject.transform.parent = sector.transform;
+            raftObject.transform.parent = sector?.transform ?? planetGO.transform;
             raftObject.transform.localPosition = info.position;
             raftObject.transform.localRotation = Quaternion.identity;
 

--- a/NewHorizons/Builder/Props/ScatterBuilder.cs
+++ b/NewHorizons/Builder/Props/ScatterBuilder.cs
@@ -35,7 +35,7 @@ namespace NewHorizons.Builder.Props
                     heightMapTexture = ImageUtilities.GetTexture(mod, heightMap.HeightMap);
                 }
                 catch (Exception) { }
-                if(heightMapTexture == null)
+                if (heightMapTexture == null)
                 {
                     radius = heightMap.MaxHeight;
                 }
@@ -50,7 +50,7 @@ namespace NewHorizons.Builder.Props
                 else prefab = GameObject.Find(propInfo.path);
                 for (int i = 0; i < propInfo.count; i++)
                 {
-                    var randomInd = (int)Random.Range(0, points.Count-1);
+                    var randomInd = (int)Random.Range(0, points.Count - 1);
                     var point = points[randomInd];
 
                     var height = radius;

--- a/NewHorizons/Builder/Props/SignalBuilder.cs
+++ b/NewHorizons/Builder/Props/SignalBuilder.cs
@@ -30,7 +30,7 @@ namespace NewHorizons.Builder.Props
         {
             Logger.Log($"Initializing SignalBuilder");
             _customSignalNames = new Dictionary<SignalName, string>();
-            _availableSignalNames = new Stack<SignalName> (new SignalName[]
+            _availableSignalNames = new Stack<SignalName>(new SignalName[]
             {
                 (SignalName)17,
                 (SignalName)18,
@@ -68,9 +68,9 @@ namespace NewHorizons.Builder.Props
                 SignalName.WhiteHole_GD_Receiver,
             });
             _customFrequencyNames = new Dictionary<SignalFrequency, string>() {
-                { SignalFrequency.Statue, "FREQ_STATUE" }, 
-                { SignalFrequency.Default, "FREQ_UNKNOWN" }, 
-                { SignalFrequency.WarpCore, "FREQ_WARP_CORE" } 
+                { SignalFrequency.Statue, "FREQ_STATUE" },
+                { SignalFrequency.Default, "FREQ_UNKNOWN" },
+                { SignalFrequency.WarpCore, "FREQ_WARP_CORE" }
             };
             _nextCustomSignalName = 200;
             _nextCustomFrequencyName = 256;
@@ -100,7 +100,7 @@ namespace NewHorizons.Builder.Props
             NumberOfFrequencies++;
 
             // This stuff happens after the signalscope is Awake so we have to change the number of frequencies now
-            GameObject.FindObjectOfType<Signalscope>()._strongestSignals = new AudioSignal[NumberOfFrequencies+1];
+            GameObject.FindObjectOfType<Signalscope>()._strongestSignals = new AudioSignal[NumberOfFrequencies + 1];
 
             return freq;
         }
@@ -131,17 +131,17 @@ namespace NewHorizons.Builder.Props
 
         public static void Make(GameObject body, Sector sector, SignalModule module, IModBehaviour mod)
         {
-            foreach(var info in module.Signals)
+            foreach (var info in module.Signals)
             {
                 Make(body, sector, info, mod);
             }
         }
 
-        public static void Make(GameObject body, Sector sector, SignalModule.SignalInfo info, IModBehaviour mod)
+        public static void Make(GameObject planetGO, Sector sector, SignalModule.SignalInfo info, IModBehaviour mod)
         {
             var signalGO = new GameObject($"Signal_{info.Name}");
             signalGO.SetActive(false);
-            signalGO.transform.parent = body.transform;
+            signalGO.transform.parent = sector?.transform ?? planetGO.transform;
             signalGO.transform.localPosition = info.Position != null ? (Vector3)info.Position : Vector3.zero;
             signalGO.layer = LayerMask.NameToLayer("AdvancedEffectVolume");
 
@@ -156,14 +156,14 @@ namespace NewHorizons.Builder.Props
             var name = StringToSignalName(info.Name);
 
             AudioClip clip = null;
-            if(info.AudioClip != null) clip = SearchUtilities.FindResourceOfTypeAndName<AudioClip>(info.AudioClip);
+            if (info.AudioClip != null) clip = SearchUtilities.FindResourceOfTypeAndName<AudioClip>(info.AudioClip);
             else if (info.AudioFilePath != null)
             {
                 try
                 {
                     clip = AudioUtilities.LoadAudio(mod.ModHelper.Manifest.ModFolderPath + "/" + info.AudioFilePath);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     Logger.LogError($"Couldn't load audio file {info.AudioFilePath} : {e.Message}");
                 }
@@ -177,7 +177,7 @@ namespace NewHorizons.Builder.Props
 
             audioSignal.SetSector(sector);
 
-            if(name == SignalName.Default) audioSignal._preventIdentification = true;
+            if (name == SignalName.Default) audioSignal._preventIdentification = true;
 
             audioSignal._frequency = frequency;
             audioSignal._name = name;
@@ -194,7 +194,7 @@ namespace NewHorizons.Builder.Props
             source.velocityUpdateMode = AudioVelocityUpdateMode.Fixed;
             source.rolloffMode = AudioRolloffMode.Custom;
 
-            if(_customCurve == null)
+            if (_customCurve == null)
                 _customCurve = GameObject.Find("Moon_Body/Sector_THM/Characters_THM/Villager_HEA_Esker/Signal_Whistling").GetComponent<AudioSource>().GetCustomCurve(AudioSourceCurveType.CustomRolloff);
 
             source.SetCustomCurve(AudioSourceCurveType.CustomRolloff, _customCurve);
@@ -210,7 +210,7 @@ namespace NewHorizons.Builder.Props
 
             var signalDetectionGO = new GameObject($"SignalDetectionTrigger_{info.Name}");
             signalDetectionGO.SetActive(false);
-            signalDetectionGO.transform.parent = body.transform;
+            signalDetectionGO.transform.parent = sector?.transform ?? planetGO.transform;
             signalDetectionGO.transform.localPosition = info.Position != null ? (Vector3)info.Position : Vector3.zero;
             signalDetectionGO.layer = LayerMask.NameToLayer("AdvancedEffectVolume");
 
@@ -223,12 +223,12 @@ namespace NewHorizons.Builder.Props
             audioSignalDetectionTrigger._trigger = owTriggerVolume;
 
             signalGO.SetActive(true);
-            signalDetectionGO.SetActive(true);                                         
+            signalDetectionGO.SetActive(true);
         }
 
         private static SignalFrequency StringToFrequency(string str)
         {
-            foreach(SignalFrequency freq in Enum.GetValues(typeof(SignalFrequency)))
+            foreach (SignalFrequency freq in Enum.GetValues(typeof(SignalFrequency)))
             {
                 if (str.Equals(freq.ToString())) return freq;
             }
@@ -249,6 +249,6 @@ namespace NewHorizons.Builder.Props
             if (customName == default) customName = AddSignalName(str);
 
             return customName;
-        } 
+        }
     }
 }

--- a/NewHorizons/Builder/Props/TornadoBuilder.cs
+++ b/NewHorizons/Builder/Props/TornadoBuilder.cs
@@ -26,12 +26,12 @@ namespace NewHorizons.Builder.Props
                 upPrefab = GameObject.Find("BrittleHollow_Body/Sector_BH/Sector_SouthHemisphere/Sector_SouthPole/Sector_Observatory/Interactables_Observatory/MockUpTornado").InstantiateInactive();
                 upPrefab.name = "Tornado_Up_Prefab";
             }
-            if(downPrefab == null)
+            if (downPrefab == null)
             {
                 downPrefab = GameObject.Find("BrittleHollow_Body/Sector_BH/Sector_SouthHemisphere/Sector_SouthPole/Sector_Observatory/Interactables_Observatory/MockDownTornado").InstantiateInactive();
                 downPrefab.name = "Tornado_Down_Prefab";
             }
-            if(soundPrefab == null)
+            if (soundPrefab == null)
             {
                 soundPrefab = GameObject.Find("GiantsDeep_Body/Sector_GD/Sector_GDInterior/Tornadoes_GDInterior/SouthernTornadoes/DownTornado_Pivot/DownTornado/AudioRail").InstantiateInactive();
                 soundPrefab.name = "AudioRail_Prefab";
@@ -39,12 +39,12 @@ namespace NewHorizons.Builder.Props
 
             float elevation;
             Vector3 position;
-            if(info.position != null)
+            if (info.position != null)
             {
                 position = info.position ?? Random.onUnitSphere * info.elevation;
                 elevation = position.magnitude;
             }
-            else if(info.elevation != 0)
+            else if (info.elevation != 0)
             {
                 position = Random.onUnitSphere * info.elevation;
                 elevation = info.elevation;
@@ -102,16 +102,16 @@ namespace NewHorizons.Builder.Props
             controller._bottomBone.localPosition = controller._bottomStartPos;
             controller._midBone.localPosition = controller._midStartPos;
             controller._topBone.localPosition = controller._topStartPos;
-            
+
             OWAssetHandler.LoadObject(tornadoGO);
             sector.OnOccupantEnterSector += (sd) => OWAssetHandler.LoadObject(tornadoGO);
 
             tornadoGO.GetComponentInChildren<CapsuleShape>().enabled = true;
 
-            if(info.tint != null)
+            if (info.tint != null)
             {
                 var colour = info.tint.ToColor();
-                foreach(var renderer in tornadoGO.GetComponentsInChildren<Renderer>())
+                foreach (var renderer in tornadoGO.GetComponentsInChildren<Renderer>())
                 {
                     renderer.material.color = colour;
                     renderer.material.SetColor("_DetailColor", colour);
@@ -119,7 +119,7 @@ namespace NewHorizons.Builder.Props
                 }
             }
 
-            if(info.wanderRate != 0)
+            if (info.wanderRate != 0)
             {
                 var wanderer = tornadoGO.AddComponent<NHTornadoWanderController>();
                 wanderer.wanderRate = info.wanderRate;

--- a/NewHorizons/Builder/Props/VolcanoBuilder.cs
+++ b/NewHorizons/Builder/Props/VolcanoBuilder.cs
@@ -16,7 +16,7 @@ namespace NewHorizons.Builder.Props
 
             var launcherGO = prefab.InstantiateInactive();
             launcherGO.transform.parent = sector.transform;
-            launcherGO.transform.localPosition = info.position == null ? Vector3.zero : (Vector3) info.position;
+            launcherGO.transform.localPosition = info.position == null ? Vector3.zero : (Vector3)info.position;
             launcherGO.transform.rotation = Quaternion.FromToRotation(launcherGO.transform.TransformDirection(Vector3.up), ((Vector3)info.position).normalized).normalized;
             launcherGO.name = "MeteorLauncher";
 
@@ -37,7 +37,8 @@ namespace NewHorizons.Builder.Props
             launcherGO.SetActive(true);
 
             // Have to null check else it breaks on reload configs
-            Main.Instance.ModHelper.Events.Unity.RunWhen(() => Main.IsSystemReady && meteorLauncher._meteorPool != null, () => {
+            Main.Instance.ModHelper.Events.Unity.RunWhen(() => Main.IsSystemReady && meteorLauncher._meteorPool != null, () =>
+            {
                 foreach (var meteor in meteorLauncher._meteorPool)
                 {
                     FixMeteor(meteor, info);

--- a/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
@@ -21,7 +21,7 @@ namespace NewHorizons.Builder.ShipLog
         {
             Material greyScaleMaterial = GameObject.Find(ShipLogHandler.PAN_ROOT_PATH + "/TimberHearth/Sprite").GetComponent<Image>().material;
             List<NewHorizonsBody> bodies = Main.BodyDict[systemName].Where(
-                b => (b.Config.ShipLog?.mapMode?.remove ?? false) == false
+                b => !(b.Config.ShipLog?.mapMode?.remove ?? false) && !b.Config.IsQuantumState
             ).ToList();
             bool flagManualPositionUsed = systemName == "SolarSystem";
             bool flagAutoPositionUsed = false;

--- a/NewHorizons/Builder/ShipLog/RumorModeBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/RumorModeBuilder.cs
@@ -218,9 +218,9 @@ namespace NewHorizons.Builder.ShipLog
                 Vector2 pivot = new Vector2(newTexture.width / 2, newTexture.height / 2);
                 return Sprite.Create(newTexture, rect, pivot);
             }
-            catch(Exception)
+            catch (Exception)
             {
-                if(logError) Logger.LogError($"Couldn't load image for {entryId} at {relativePath}");
+                if (logError) Logger.LogError($"Couldn't load image for {entryId} at {relativePath}");
                 return null;
             }
         }

--- a/NewHorizons/Components/Orbital/OrbitalParameters.cs
+++ b/NewHorizons/Components/Orbital/OrbitalParameters.cs
@@ -8,15 +8,15 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Components.Orbital
 {
-    public class OrbitalParameters
+    public class OrbitalParameters : IOrbitalParameters
     {
-        public float Inclination { get; private set; }
-        public float SemiMajorAxis { get; private set; }
-        public float LongitudeOfAscendingNode { get; private set; }
-        public float Eccentricity { get; private set; }
-        public float ArgumentOfPeriapsis { get; private set; }
-        public float TrueAnomaly { get; private set; }
-        public float Period { get; private set; }
+        public float Inclination { get; set; }
+        public float SemiMajorAxis { get; set; }
+        public float LongitudeOfAscendingNode { get; set; }
+        public float Eccentricity { get; set; }
+        public float ArgumentOfPeriapsis { get; set; }
+        public float TrueAnomaly { get; set; }
+        public float Period { get; set; }
 
         public Vector3 InitialPosition { get; private set; }
         public Vector3 InitialVelocity { get; private set; }
@@ -111,6 +111,11 @@ namespace NewHorizons.Components.Orbital
             var R2 = Quaternion.AngleAxis(inclination, R1 * Vector3.left);
 
             return R1 * R2 * vector;
+        }
+
+        public OrbitalParameters GetOrbitalParameters(Gravity primaryGravity, Gravity secondaryGravity)
+        {
+            return FromTrueAnomaly(primaryGravity, secondaryGravity, Eccentricity, SemiMajorAxis, Inclination, ArgumentOfPeriapsis, LongitudeOfAscendingNode, TrueAnomaly);
         }
     }
 }

--- a/NewHorizons/Components/QuantumPlanet.cs
+++ b/NewHorizons/Components/QuantumPlanet.cs
@@ -1,0 +1,109 @@
+﻿using NewHorizons.Builder.General;
+using NewHorizons.Builder.Orbital;
+using NewHorizons.Components.Orbital;
+using NewHorizons.External;
+using NewHorizons.Handlers;
+using NewHorizons.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using Random = UnityEngine.Random;
+using Logger = NewHorizons.Utility.Logger;
+
+namespace NewHorizons.Components
+{
+    public class QuantumPlanet : QuantumObject
+    {
+        public List<State> states = new List<State>();
+
+        private int _currentIndex;
+        private NHAstroObject _astroObject;
+        private ConstantForceDetector _detector;
+        private AlignWithTargetBody _alignment;
+        private OWRigidbody _rb;
+
+        public override void Awake()
+        {
+            base.Awake();
+
+            _astroObject = GetComponent<NHAstroObject>();
+            _detector = GetComponentInChildren<ConstantForceDetector>();
+            _alignment = GetComponent<AlignWithTargetBody>();
+            _rb = GetComponent<OWRigidbody>();
+        }
+
+        public override void Start()
+        {
+            base.Start();
+
+            foreach(var state in states)
+            {
+                state.sector?.gameObject?.SetActive(false);
+            }
+
+            ChangeQuantumState(true);
+        }
+
+        public override bool ChangeQuantumState(bool skipInstantVisibilityCheck)
+        {
+            Logger.Log($"Changing quantum state");
+
+            if (states.Count <= 1) return false;
+
+            var newIndex = _currentIndex;
+            while(newIndex == _currentIndex)
+            {
+                newIndex = Random.Range(0, states.Count);
+            }
+
+            var oldState = states[_currentIndex];
+            var newState = states[newIndex];
+
+            if (newState.sector != null) SetNewSector(oldState, newState);
+            if(newState.orbit != null) SetNewOrbit(newState);
+
+            _currentIndex = newIndex;
+
+            return true;
+        }
+
+        private void SetNewSector(State oldState, State newState)
+        {
+            oldState.sector.gameObject.SetActive(false);
+            newState.sector.gameObject.SetActive(true);
+        }
+
+        private void SetNewOrbit(State state)
+        {
+            var currentOrbit = state.orbit;
+
+            var primaryBody = AstroObjectLocator.GetAstroObject(currentOrbit.PrimaryBody);
+
+            _astroObject._primaryBody = primaryBody;
+            DetectorBuilder.SetDetector(primaryBody, _astroObject, _detector);
+            if (_alignment != null) _alignment.SetTargetBody(primaryBody.GetComponent<OWRigidbody>());
+
+            PlanetCreationHandler.UpdatePosition(gameObject, currentOrbit, primaryBody, _astroObject);
+
+            var primaryGravity = new Gravity(primaryBody.GetGravityVolume());
+            var secondaryGravity = new Gravity(_astroObject.GetGravityVolume());
+
+            _rb.SetVelocity(currentOrbit.GetOrbitalParameters(primaryGravity, secondaryGravity).InitialVelocity);
+        }
+
+        public class State
+        {
+            public Sector sector { get; set; }
+            public OrbitModule orbit { get; set; }
+
+            public State(Sector sector, OrbitModule orbit)
+            {
+                this.sector = sector;
+                this.orbit = orbit;
+            }
+        }
+    }
+}

--- a/NewHorizons/Components/QuantumPlanet.cs
+++ b/NewHorizons/Components/QuantumPlanet.cs
@@ -89,6 +89,7 @@ namespace NewHorizons.Components
             DetectorBuilder.SetDetector(primaryBody, _astroObject, _detector);
             if (_alignment != null) _alignment.SetTargetBody(primaryBody.GetComponent<OWRigidbody>());
 
+            currentOrbit.TrueAnomaly = Random.Range(0, 360);
             PlanetCreationHandler.UpdatePosition(gameObject, currentOrbit, primaryBody, _astroObject);
 
             var primaryGravity = new Gravity(primaryBody.GetGravityVolume());

--- a/NewHorizons/Components/QuantumPlanet.cs
+++ b/NewHorizons/Components/QuantumPlanet.cs
@@ -18,6 +18,7 @@ namespace NewHorizons.Components
     public class QuantumPlanet : QuantumObject
     {
         public List<State> states = new List<State>();
+        public State groundState;
 
         private int _currentIndex;
         private NHAstroObject _astroObject;
@@ -33,6 +34,8 @@ namespace NewHorizons.Components
             _detector = GetComponentInChildren<ConstantForceDetector>();
             _alignment = GetComponent<AlignWithTargetBody>();
             _rb = GetComponent<OWRigidbody>();
+
+            GlobalMessenger.AddListener("PlayerBlink", new Callback(OnPlayerBlink));
         }
 
         public override void Start()
@@ -62,8 +65,8 @@ namespace NewHorizons.Components
             var oldState = states[_currentIndex];
             var newState = states[newIndex];
 
-            if (newState.sector != null) SetNewSector(oldState, newState);
-            if(newState.orbit != null) SetNewOrbit(newState);
+            if (newState.sector != null && newState.sector != oldState.sector) SetNewSector(oldState, newState);
+            if (newState.orbit != null && newState.orbit != oldState.orbit) SetNewOrbit(newState);
 
             _currentIndex = newIndex;
 
@@ -92,6 +95,19 @@ namespace NewHorizons.Components
             var secondaryGravity = new Gravity(_astroObject.GetGravityVolume());
 
             _rb.SetVelocity(currentOrbit.GetOrbitalParameters(primaryGravity, secondaryGravity).InitialVelocity);
+        }
+
+        private void OnPlayerBlink()
+        {
+            if (base.IsVisible())
+            {
+                base.Collapse(true);
+            }
+        }
+
+        public override bool IsPlayerEntangled()
+        {
+            return states[_currentIndex].sector.ContainsAnyOccupants(DynamicOccupant.Player);
         }
 
         public class State

--- a/NewHorizons/External/AtmosphereModule.cs
+++ b/NewHorizons/External/AtmosphereModule.cs
@@ -25,5 +25,13 @@ namespace NewHorizons.External
         public bool HasOxygen { get; set; }
         public bool HasAtmosphere { get; set; }
         public MColor AtmosphereTint { get; set; }
+
+        public class AirInfo
+        {
+            public float Scale { get; set; }
+            public bool HasOxygen { get; set; }
+            public bool IsRaining { get; set; }
+            public bool IsSnowing { get; set; }
+        }
     }
 }

--- a/NewHorizons/External/Configs/IPlanetConfig.cs
+++ b/NewHorizons/External/Configs/IPlanetConfig.cs
@@ -11,6 +11,7 @@ namespace NewHorizons.External.Configs
         string[] ChildrenToDestroy { get; }
         int BuildPriority { get; }
         bool CanShowOnTitle { get; }
+        bool IsQuantumState { get; }
         BaseModule Base { get; }
         AtmosphereModule Atmosphere { get; }
         OrbitModule Orbit { get; }

--- a/NewHorizons/External/Configs/PlanetConfig.cs
+++ b/NewHorizons/External/Configs/PlanetConfig.cs
@@ -14,6 +14,7 @@ namespace NewHorizons.External.Configs
         public string[] ChildrenToDestroy { get; set; }
         public int BuildPriority { get; set; } = -1;
         public bool CanShowOnTitle { get; set; } = true;
+        public bool IsQuantumState { get; set; }
         public BaseModule Base { get; set; }
         public AtmosphereModule Atmosphere { get; set; }
         public OrbitModule Orbit { get; set; }

--- a/NewHorizons/External/VariableSize/SingularityModule.cs
+++ b/NewHorizons/External/VariableSize/SingularityModule.cs
@@ -14,5 +14,6 @@ namespace NewHorizons.External.VariableSize
         public string TargetStarSystem;
         public string Type; //BlackHole or WhiteHole
         public MVector3 Position;
+        public bool MakeZeroGVolume = true;
     }
 }

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -166,7 +166,16 @@ namespace NewHorizons.Handlers
                             var rootSector = quantumPlanet.GetComponentInChildren<Sector>();
                             var groundOrbit = _dict[ao].Config.Orbit;
 
-                            quantumPlanet.states.Add(new QuantumPlanet.State(rootSector, groundOrbit));
+                            quantumPlanet.groundState = new QuantumPlanet.State(rootSector, groundOrbit);
+                            quantumPlanet.states.Add(quantumPlanet.groundState);
+
+                            var visibilityTracker = new GameObject("VisibilityTracker_Sphere");
+                            visibilityTracker.transform.parent = existingPlanet.transform;
+                            visibilityTracker.transform.localPosition = Vector3.zero;
+                            var sphere = visibilityTracker.AddComponent<SphereShape>();
+                            sphere.radius = GetSphereOfInfluence(_dict[ao]);
+                            var tracker = visibilityTracker.AddComponent<ShapeVisibilityTracker>();
+                            quantumPlanet._visibilityTrackers = new VisibilityTracker[] { tracker };
                         }
 
                         var rb = existingPlanet.GetComponent<OWRigidbody>();
@@ -177,10 +186,10 @@ namespace NewHorizons.Handlers
                         SharedGenerateBody(body, existingPlanet, sector, rb);
 
                         // If nothing was generated then forget the sector
-                        if (sector.transform.childCount == 0) sector = null;
+                        if (sector.transform.childCount == 0) sector = quantumPlanet.groundState.sector;
 
                         // If semimajor axis is 0 then forget the orbit
-                        var orbit = body.Config.Orbit.SemiMajorAxis == 0 ? null : body.Config.Orbit;
+                        var orbit = body.Config.Orbit.SemiMajorAxis == 0 ? quantumPlanet.groundState.orbit : body.Config.Orbit;
 
                         quantumPlanet.states.Add(new QuantumPlanet.State(sector, orbit));
                     }

--- a/NewHorizons/Handlers/PlanetDestructionHandler.cs
+++ b/NewHorizons/Handlers/PlanetDestructionHandler.cs
@@ -9,9 +9,9 @@ using System.Threading.Tasks;
 using UnityEngine;
 using Logger = NewHorizons.Utility.Logger;
 
-namespace NewHorizons.Builder.General
+namespace NewHorizons.Handlers
 {
-    static class PlanetDestroyer
+    static class PlanetDestructionHandler
     {
         private static readonly string[] _solarSystemBodies = new string[]
         {

--- a/NewHorizons/Handlers/PlanetDestructionHandler.cs
+++ b/NewHorizons/Handlers/PlanetDestructionHandler.cs
@@ -11,7 +11,7 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Handlers
 {
-    static class PlanetDestructionHandler
+    public static class PlanetDestructionHandler
     {
         private static readonly string[] _solarSystemBodies = new string[]
         {

--- a/NewHorizons/Handlers/TitleSceneHandler.cs
+++ b/NewHorizons/Handlers/TitleSceneHandler.cs
@@ -85,7 +85,7 @@ namespace NewHorizons.Handlers
                 heightMap.TextureMap = body.Config.Atmosphere.Cloud;
             }
 
-            HeightMapBuilder.Make(titleScreenGO, heightMap, body.Mod);
+            HeightMapBuilder.Make(titleScreenGO, null, heightMap, body.Mod);
 
             GameObject pivot = GameObject.Instantiate(GameObject.Find("Scene/Background/PlanetPivot"), GameObject.Find("Scene/Background").transform);
             pivot.GetComponent<RotateTransform>()._degreesPerSecond = 10f;
@@ -101,7 +101,7 @@ namespace NewHorizons.Handlers
                 newRing.InnerRadius = size * 1.2f;
                 newRing.OuterRadius = size * 2f;
                 newRing.Texture = body.Config.Ring.Texture;
-                var ring = RingBuilder.Make(titleScreenGO, newRing, body.Mod);
+                var ring = RingBuilder.Make(titleScreenGO, null, newRing, body.Mod);
                 titleScreenGO.transform.localScale = Vector3.one * 0.8f;
             }
 

--- a/NewHorizons/Utility/AddDebugShape.cs
+++ b/NewHorizons/Utility/AddDebugShape.cs
@@ -2,7 +2,7 @@
 
 namespace NewHorizons.Utility
 {
-    static class AddDebugShape
+    public static class AddDebugShape
     {
         public static GameObject AddSphere(GameObject obj, float radius, Color color)
         {

--- a/NewHorizons/Utility/ImageUtilities.cs
+++ b/NewHorizons/Utility/ImageUtilities.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace NewHorizons.Utility
 {
-    static class ImageUtilities
+    public static class ImageUtilities
     {
         private static Dictionary<string, Texture2D> _loadedTextures = new Dictionary<string, Texture2D>();
         private static List<Texture2D> _generatedTextures = new List<Texture2D>();

--- a/NewHorizons/Utility/MakeMeshDoubleFaced.cs
+++ b/NewHorizons/Utility/MakeMeshDoubleFaced.cs
@@ -2,7 +2,7 @@
 
 namespace NewHorizons.Utility
 {
-    class MakeMeshDoubleFaced : MonoBehaviour
+    public class MakeMeshDoubleFaced : MonoBehaviour
     {
         private void Start()
         {

--- a/NewHorizons/schema.json
+++ b/NewHorizons/schema.json
@@ -936,7 +936,7 @@
               },
               "normal": {
                 "$ref": "#/$defs/vector3",
-                "description": "The normal vector for this object. Only used for writing on walls to orient it properly."
+                "description": "The normal vector for this object. Used for writing on walls and positioning computers."
               },
               "rotation": {
                 "$ref": "#/$defs/vector3",

--- a/NewHorizons/schema.json
+++ b/NewHorizons/schema.json
@@ -1166,6 +1166,11 @@
         },
         "position": {
           "$ref": "#/$defs/vector3"
+        },
+        "makeZeroGVolume": {
+          "type": "boolean",
+          "default": true,
+          "description": "Only for White Holes. Should this white hole repel the player from it."
         }
       }
     },


### PR DESCRIPTION
- Allow creating quantum states of planets. Just create a new planet config with the same `name` field, but with `IsQuantumPlanet` set to `true`. Anything that can be changed on an existing planet can be set on a quantum state, including the orbit. Stock planets can't be modified to become quantum however.
- Fixed rotation of details after using `alignWithNormal`.
- Allow Nomai computers to be aligned to a specific normal vector, so you can have them easily sit on an inclined surface.
- Allow toggling zero-G volume around white holes using `MakeZeroGVolume` in `Singularity`.
- Behind the scenes, made all classes `public` to make it easier to reference NH in code.