### PR TITLE
Hide warp prompt in landing cam

### DIFF
--- a/NewHorizons/Components/ShipLogStarChartMode.cs
+++ b/NewHorizons/Components/ShipLogStarChartMode.cs
@@ -31,7 +31,6 @@ namespace NewHorizons.Components
         private NotificationData _warpNotificationData = null;
 
         private int _nextCardIndex;
-        private bool _isAtFlightConsole;
 
         private void Awake()
         {
@@ -51,10 +50,6 @@ namespace NewHorizons.Components
             _targetSystemPrompt = new ScreenPrompt(InputLibrary.markEntryOnHUD, "Lock Autopilot to Star System", 0, ScreenPrompt.DisplayState.Normal, false);
 
             GlobalMessenger<ReferenceFrame>.AddListener("TargetReferenceFrame", new Callback<ReferenceFrame>(OnTargetReferenceFrame));
-            GlobalMessenger<OWRigidbody>.AddListener("EnterFlightConsole", new Callback<OWRigidbody>(OnEnterFlightConsole));
-            GlobalMessenger.AddListener("ExitFlightConsole", new Callback(OnExitFlightConsole));
-            GlobalMessenger.AddListener("GamePaused", new Callback(OnGamePaused));
-            GlobalMessenger.AddListener("GameUnpaused", new Callback(OnGameUnpaused));
 
             _nextCardIndex = 0;
             foreach (var starSystem in Main.SystemDict.Keys)
@@ -96,40 +91,8 @@ namespace NewHorizons.Components
         public void OnDestroy()
         {
             GlobalMessenger<ReferenceFrame>.RemoveListener("TargetReferenceFrame", new Callback<ReferenceFrame>(OnTargetReferenceFrame));
-            GlobalMessenger<OWRigidbody>.RemoveListener("EnterFlightConsole", new Callback<OWRigidbody>(OnEnterFlightConsole));
-            GlobalMessenger.RemoveListener("ExitFlightConsole", new Callback(OnExitFlightConsole));
-            GlobalMessenger.RemoveListener("GamePaused", new Callback(OnGamePaused));
-            GlobalMessenger.RemoveListener("GameUnpaused", new Callback(OnGameUnpaused));
 
             Locator.GetPromptManager().RemoveScreenPrompt(_warpPrompt, PromptPosition.UpperLeft);
-        }
-
-        private void OnEnterFlightConsole(OWRigidbody _)
-        {
-            _isAtFlightConsole = true;
-            if (_target != null)
-            {
-                _warpPrompt.SetVisibility(true);
-            }
-        }
-
-        private void OnExitFlightConsole()
-        {
-            _isAtFlightConsole = false;
-            _warpPrompt.SetVisibility(false);
-        }
-
-        private void OnGamePaused()
-        {
-            _warpPrompt.SetVisibility(false);
-        }
-
-        private void OnGameUnpaused()
-        {
-            if (_target != null && _isAtFlightConsole)
-            {
-                _warpPrompt.SetVisibility(true);
-            }
         }
 
         public GameObject CreateCard(string uniqueID, Transform parent, Vector2 position)
@@ -329,8 +292,6 @@ namespace NewHorizons.Components
             if (playSound) _oneShotSource.PlayOneShot(global::AudioType.ShipLogMarkLocation, 1f);
             _target.SetMarkedOnHUD(false);
             _target = null;
-
-            _warpPrompt.SetVisibility(false);
         }
 
         public string GetTargetStarSystem()
@@ -343,7 +304,7 @@ namespace NewHorizons.Components
             return OWInput.IsInputMode(InputMode.ShipCockpit) && _target != null;
         }
 
-        private void Update()
+        public void UpdateWarpPromptVisibility()
         {
             _warpPrompt.SetVisibility(IsWarpDriveAvailable());
         }

--- a/NewHorizons/Patches/WarpDrivePatches.cs
+++ b/NewHorizons/Patches/WarpDrivePatches.cs
@@ -24,6 +24,7 @@ namespace NewHorizons.Patches
         {
             if (!Main.HasWarpDrive) return true;
 
+            StarChartHandler.ShipLogStarChartMode.UpdateWarpPromptVisibility();
             if (__instance._playerAtFlightConsole && OWInput.IsNewlyPressed(InputLibrary.autopilot, InputMode.ShipCockpit))
             {
                 var targetSystem = StarChartHandler.ShipLogStarChartMode.GetTargetStarSystem();


### PR DESCRIPTION
The "Engage Warp To ..." prompt is visible when using the landing cam but using the autopilot key in this mod does nothing:
![prompt](https://user-images.githubusercontent.com/22490080/170650375-9cea65d4-489f-4bf5-9e30-c461882f5484.jpg)

The `ShipLogStarChartMode.Update` method already had the correct logic to set the visibility when the warping was possible, but this method wasn't being called because the mode wasn't enable. The visibility was updated on events instead, so I removed this and now I call the previously `Update` method (now `UpdateWarpPromptVisibility`) on `ShipCockpitController.Update` postfix.