### PR TITLE
vision torch no longer blocks equipping ship tools

### DIFF
--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -381,5 +381,6 @@ namespace NewHorizons.Builder.Props
     {
         public MindSlideCollection slideCollection;
         public SlideCollectionContainer slideCollectionContainer;
+        public OWEvent.OWCallback onSlidesComplete;
     }
 }

--- a/NewHorizons/Patches/ToolModeSwapperPatches.cs
+++ b/NewHorizons/Patches/ToolModeSwapperPatches.cs
@@ -27,8 +27,9 @@ namespace NewHorizons.Patches
                 mode == ToolMode.Probe || 
                 mode == ToolMode.SignalScope || 
                 mode == ToolMode.Translator;
+            var isInShip = UnityEngine.GameObject.FindObjectOfType<ShipCockpitController>()._playerAtFlightConsole;
 
-            if (isHoldingVisionTorch && swappingToRestrictedTool) return false;
+            if (!isInShip && isHoldingVisionTorch && swappingToRestrictedTool) return false;
 
             return true;
         }

--- a/NewHorizons/Patches/ToolModeSwapperPatches.cs
+++ b/NewHorizons/Patches/ToolModeSwapperPatches.cs
@@ -27,7 +27,7 @@ namespace NewHorizons.Patches
                 mode == ToolMode.Probe || 
                 mode == ToolMode.SignalScope || 
                 mode == ToolMode.Translator;
-            var isInShip = UnityEngine.GameObject.FindObjectOfType<ShipCockpitController>()._playerAtFlightConsole;
+            var isInShip = UnityEngine.GameObject.FindObjectOfType<ShipCockpitController>()?._playerAtFlightConsole ?? false;
 
             if (!isInShip && isHoldingVisionTorch && swappingToRestrictedTool) return false;
 

--- a/NewHorizons/Patches/VisionTorchPatches.cs
+++ b/NewHorizons/Patches/VisionTorchPatches.cs
@@ -20,6 +20,8 @@ namespace NewHorizons.Patches
 			var t = hitObj.GetComponent<VisionTorchTarget>();
             if (t != null) //(hitObj.CompareTag("PrisonerDetector"))
 		    {
+                __instance._mindProjector.OnProjectionComplete += t.onSlidesComplete;
+
                 // _slideCollectionItem is actually a reference to a SlideCollectionContainer. Not a slide reel item
 				__instance._mindProjector._slideCollectionItem = t.slideCollectionContainer; 
 				__instance._mindProjector._mindSlideCollection = t.slideCollection;
@@ -35,6 +37,19 @@ namespace NewHorizons.Patches
                 return false;
             }
 
+            return true;
+        }
+
+        
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(MindProjectorTrigger), nameof(MindProjectorTrigger.OnTriggerVolumeExit))]
+	    private static bool MindProjectorTrigger_OnTriggerVolumeExit(MindProjectorTrigger __instance, GameObject hitObj)
+        {
+            var t = hitObj.GetComponent<VisionTorchTarget>();
+            if (t != null) //(hitObj.CompareTag("PrisonerDetector"))
+		    {
+                __instance._mindProjector.OnProjectionComplete -= t.onSlidesComplete;
+            }
             return true;
         }
     }


### PR DESCRIPTION
### What's fixed?

- in the title: vision torch no longer blocks equipping ship tools 
  - ie if you're piloting your ship while holding a vision torch, you can use the scout launcher, signalscope, etc, as expected
- Vision torch targets now support the "on vision complete" event
