### PR TITLE
fixes campfires spawned using DetailBuilder

### DIFF
--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -147,6 +147,20 @@ namespace NewHorizons.Builder.Props
                         torchItem.mindProjectorTrigger.enabled = true;
                         torchItem.mindSlideProjector._mindProjectorImageEffect = GameObject.Find("Player_Body/PlayerCamera").GetComponent<MindProjectorImageEffect>();
                     }
+
+                    // fix campfires
+                    if (component is InteractVolume interactVolume)
+                    {
+                        interactVolume._playerCam = GameObject.Find("Player_Body/PlayerCamera").GetComponent<OWCamera>();
+                    }
+                    if (component is PlayerAttachPoint playerAttachPoint)
+                    {
+                        var playerBody = GameObject.Find("Player_Body");
+                        playerAttachPoint._playerController = playerBody.GetComponent<PlayerCharacterController>();
+                        playerAttachPoint._playerOWRigidbody = playerBody.GetComponent<OWRigidbody>();
+                        playerAttachPoint._playerTransform = playerBody.transform;
+                        playerAttachPoint._fpsCamController = GameObject.Find("Player_Body/PlayerCamera").GetComponent<PlayerCameraController>();
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
### What's fixed?

- In detail builder, added handling for two component types:
  - InteractVolume
  - PlayerAttachPoint
- This fixes campfires (before they'd create an ever increasing number of input prompts while you looked at them, and also wouldn't let you roast marshmallows), and possibly other props