### PR TITLE
Fix slide not showing after blackFrameDuration

### DIFF
--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -96,7 +96,7 @@ namespace NewHorizons.Builder.Props
             imageLoader.imageLoadedEvent.AddListener(
                 (Texture2D tex, int index) => 
                 { 
-                    slideCollection.slides[index].textureOverride = ImageUtilities.Invert(tex); 
+                    slideCollection.slides[index]._image = ImageUtilities.Invert(tex); 
 
                     // Track the first 15 to put on the slide reel object
                     if (index < 15) 
@@ -176,7 +176,7 @@ namespace NewHorizons.Builder.Props
 
                 slideCollection.slides[i] = slide;
             }
-            imageLoader.imageLoadedEvent.AddListener((Texture2D tex, int index) => { slideCollection.slides[index].textureOverride = ImageUtilities.Invert(tex); });
+            imageLoader.imageLoadedEvent.AddListener((Texture2D tex, int index) => { slideCollection.slides[index]._image = ImageUtilities.Invert(tex); });
 
             slideCollectionContainer.slideCollection = slideCollection;
 
@@ -185,8 +185,8 @@ namespace NewHorizons.Builder.Props
 
             // Change the picture on the lens
             var lens = projectorObj.transform.Find("Spotlight/Prop_IP_SingleSlideProjector/Projector_Lens").GetComponent<MeshRenderer>();
-            lens.materials[1].mainTexture = slideCollection.slides[0]._textureOverride;
-            lens.materials[1].SetTexture(EmissionMap, slideCollection.slides[0]._textureOverride);
+            lens.materials[1].mainTexture = slideCollection.slides[0]._image;
+            lens.materials[1].SetTexture(EmissionMap, slideCollection.slides[0]._image);
 
             projectorObj.SetActive(true);
         }
@@ -224,7 +224,7 @@ namespace NewHorizons.Builder.Props
 
                 slideCollection.slides[i] = slide;
             }
-            imageLoader.imageLoadedEvent.AddListener((Texture2D tex, int index) => { slideCollection.slides[index].textureOverride = tex; });
+            imageLoader.imageLoadedEvent.AddListener((Texture2D tex, int index) => { slideCollection.slides[index]._image = tex; });
 
 
             // attatch a component to store all the data for the slides that play when a vision torch scans this target
@@ -298,7 +298,7 @@ namespace NewHorizons.Builder.Props
             imageLoader.imageLoadedEvent.AddListener(
                 (Texture2D tex, int index) => 
                 { 
-                    slideCollection.slides[index].textureOverride = tex;
+                    slideCollection.slides[index]._image = tex;
                     displaySlidesLoaded++; // threading moment
 
                     if (displaySlidesLoaded >= slides.Length)

--- a/NewHorizons/Patches/AutoSlideProjectorPatches.cs
+++ b/NewHorizons/Patches/AutoSlideProjectorPatches.cs
@@ -1,0 +1,14 @@
+﻿using HarmonyLib;
+
+namespace NewHorizons.Patches;
+
+[HarmonyPatch]
+public class AutoSlideProjectorPatches
+{
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(AutoSlideProjector), nameof(AutoSlideProjector.Play))]
+    public static void AutoSlideProjector_Play(ref SlideCollectionContainer ____slideCollectionItem)
+    {
+        ____slideCollectionItem.enabled = true;
+    }
+}


### PR DESCRIPTION
`blackFrameDuration` is supposed to add a black frame of a given duration before showing the real slide (it also blocks the manual projector to change the slide for that duration). However, NH has a bug and after that duration, the real image of the reel isn't displayed. This happens because `SlideBlackFrameModule`  sets the `textureOverride` of the slide to a black texture and then, after the `blackFrameDuration`, to `null`. And NH stores the texture of the reel also in `textureOverride`, so to fix it I made it store in `_image` instead. 

This works because  `textureOverride` takes precedence over `_image` when it isn't `null` (see `Slide.GetTexture()`), meaning that when `SlideBlackFrameModule` sets it to the black texture, the texture of the slide will be black, and then after the `blackFrameDuration`  `textureOverride` would be set back to `null`, so the texture of the slide would be the `_image` we set.

Additionally, this PR also fixes a bug in which the `SlideCollectionContainer` of an `AutoSlideProjectorPatches` was never enabled after playing the slide (it's disabled on stop when exiting the sector of the projector, but it isn't enabled on play when entering the sector). As a result of this, `SlideCollectionContainer.Update()`  is never called, and so  `SlideBlackFrameModule.Update()` isn't called either, causing the reel to permanently bock in the black frame and not move to the next slide (because `SlideBlackFrameModule` sets `_changeSlidesAllowed` set to `false` and never back to `true`). This also happens in vanilla but it isn't really an issue there because afaik `SlideBlackFrameModule` isn't used in vanilla. To fix it I added a postfix patch to enable the `SlideCollectionContainer` on play.

To quickly test this, add `blackFrameDuration` to the `autoProjector` of [New Horizons Examples](https://github.com/xen-42/ow-new-horizons-examples/blob/a24852627628c8252f0958a8606d3dafd7204f3c/planets/ExistingPlanets/timber_hearth.json#L162):
```json
			{
				"position": {"x": 38.0319, "y": -36.9151, "z": 185.9331},
				"rotation": {"x": 85.3647, "y": 168.7207, "z": 155.2558},
				"type": "autoProjector",
				"slides": [
					{"imagePath": "planets/assets/slides/nh.png"},
					{"imagePath": "planets/assets/slides/SlateWithAGun.png", "blackFrameDuration": 2},
					{"imagePath": "planets/assets/slides/HearthianFlushed.png"}
				]
			}
```