### PR TITLE
Fix prop placer for custom planets

### DIFF
--- a/NewHorizons/Utility/AstroObjectLocator.cs
+++ b/NewHorizons/Utility/AstroObjectLocator.cs
@@ -70,6 +70,7 @@ namespace NewHorizons.Utility
             {
                 Logger.Log($"Registering [{ao.name}] as [{key}]");
                 _customAstroObjectDictionary.Add(key, ao);
+                _customAstroObjectDictionary.Add(ao.name, ao);
             }
         }
 

--- a/NewHorizons/Utility/AstroObjectLocator.cs
+++ b/NewHorizons/Utility/AstroObjectLocator.cs
@@ -78,16 +78,17 @@ namespace NewHorizons.Utility
         {
             var key = ao._name == AstroObject.Name.CustomString ? ao.GetCustomName() : ao._name.ToString();
             _customAstroObjectDictionary.Remove(key);
+            _customAstroObjectDictionary.Remove(ao.name);
         }
 
         public static AstroObject[] GetAllAstroObjects()
         {
-            return _customAstroObjectDictionary.Values.ToArray();
+            return _customAstroObjectDictionary.Values.Distinct().ToArray();
         }
 
         public static GameObject[] GetMoons(AstroObject primary)
         {
-            return _customAstroObjectDictionary.Values.Where(x => x._primaryBody == primary).Select(x => x.gameObject).ToArray();
+            return _customAstroObjectDictionary.Values.Distinct().Where(x => x._primaryBody == primary).Select(x => x.gameObject).ToArray();
         }
 
         public static GameObject[] GetChildren(AstroObject primary)

--- a/NewHorizons/Utility/DebugUtilities/DebugPropPlacer.cs
+++ b/NewHorizons/Utility/DebugUtilities/DebugPropPlacer.cs
@@ -144,13 +144,10 @@ namespace NewHorizons.Utility.DebugUtilities
 
         public static string GetAstroObjectName(string bodyName)
         {
-            if (bodyName.EndsWith("_Body")) bodyName = bodyName.Substring(0, bodyName.Length-"_Body".Length);
-
             var astroObject = AstroObjectLocator.GetAstroObject(bodyName);
             if (astroObject == null) return null;
 
             var astroObjectName = astroObject.name;
-            if (astroObjectName.EndsWith("_Body")) astroObjectName = astroObjectName.Substring(0, astroObjectName.Length-"_Body".Length);
 
             return astroObjectName;
         }
@@ -202,7 +199,7 @@ namespace NewHorizons.Utility.DebugUtilities
 
             string bodyName = GetAstroObjectName(bodyGameObjectName);
             
-            Logger.Log("Adding prop to " + Main.Instance.CurrentStarSystem + "::" + bodyName);
+            Logger.Log("Adding prop to " + Main.Instance.CurrentStarSystem + "::" + bodyName + "    (passed name: "+bodyGameObjectName+")");
             
 
             detailInfo = detailInfo == null ? new DetailInfo() : detailInfo;

--- a/NewHorizons/Utility/DebugUtilities/DebugPropPlacer.cs
+++ b/NewHorizons/Utility/DebugUtilities/DebugPropPlacer.cs
@@ -199,7 +199,7 @@ namespace NewHorizons.Utility.DebugUtilities
 
             string bodyName = GetAstroObjectName(bodyGameObjectName);
             
-            Logger.Log("Adding prop to " + Main.Instance.CurrentStarSystem + "::" + bodyName + "    (passed name: "+bodyGameObjectName+")");
+            Logger.Log($"Adding prop to {Main.Instance.CurrentStarSystem}::{bodyName}  (passed name: {bodyGameObjectName})");
             
 
             detailInfo = detailInfo == null ? new DetailInfo() : detailInfo;


### PR DESCRIPTION
### What's new?
- made AstroObjectLocator also register astro objects under the name of their game object, eg MyPlanet_Body
- (fixes an issue where prop placer wouldn't save new props placed on custom planets) 