### PR TITLE
1.4.2

### DIFF
--- a/NewHorizons/Builder/Atmosphere/FogBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/FogBuilder.cs
@@ -44,9 +44,12 @@ namespace NewHorizons.Builder.Atmosphere
             var colorRampTexture = atmo.fogTint == null ? _ramp : ImageUtilities.TintImage(_ramp, atmo.fogTint.ToColor());
             PFC.fogColorRampTexture = colorRampTexture;
             PFC.fogColorRampIntensity = 1f;
-            PFC.fogTint = atmo.fogTint.ToColor();
+            if (atmo.fogTint != null)
+            {
+                PFC.fogTint = atmo.fogTint.ToColor();
 
-            MR.material.SetColor(Tint, atmo.fogTint.ToColor());
+                MR.material.SetColor(Tint, atmo.fogTint.ToColor());
+            }
             MR.material.SetFloat(Radius, atmo.fogSize);
             MR.material.SetFloat(Density, atmo.fogDensity);
             MR.material.SetFloat(DensityExponent, 1);

--- a/NewHorizons/Builder/Body/Geometry/CubeSphere.cs
+++ b/NewHorizons/Builder/Body/Geometry/CubeSphere.cs
@@ -132,7 +132,8 @@ namespace NewHorizons.Builder.Body.Geometry
 
             float sampleX = heightMap.width * longitude / 360f;
             float sampleY = heightMap.height * latitude / 180f;
-            if (sampleX > heightMap.width) sampleX -= heightMap.width; // TODO: find out if this actually does anything
+            if (sampleX > heightMap.width) sampleX -= heightMap.width; 
+            if (sampleX < 0) sampleX += heightMap.width;
 
             float relativeHeight = heightMap.GetPixel((int)sampleX, (int)sampleY).r;
 

--- a/NewHorizons/Patches/PlayerFogWarpDetectorPatches.cs
+++ b/NewHorizons/Patches/PlayerFogWarpDetectorPatches.cs
@@ -1,5 +1,4 @@
 using HarmonyLib;
-using UnityEngine;
 
 namespace NewHorizons.Patches
 {
@@ -9,24 +8,22 @@ namespace NewHorizons.Patches
         // Morbius moment: they only let fog go away if there is a fog controller on the planet near you
         // However you can leave these volumes with fog on your screen, or have fog applied by a bramble node on a fogless planet
 
-        [HarmonyPrefix]
+        [HarmonyPostfix]
         [HarmonyPatch(typeof(PlayerFogWarpDetector), nameof(PlayerFogWarpDetector.LateUpdate))]
-        public static bool PlayerFogWarpDetector_LateUpdate(PlayerFogWarpDetector __instance)
+        public static void PlayerFogWarpDetector_LateUpdate(PlayerFogWarpDetector __instance)
         {
             if (PlanetaryFogController.GetActiveFogSphere() == null)
             {
-                float num = __instance._targetFogFraction;
+                __instance._fogFraction = 0;
                 if (__instance._playerEffectBubbleController != null)
                 {
-                    __instance._playerEffectBubbleController.SetFogFade(0, __instance._fogColor);
+                    __instance._playerEffectBubbleController.SetFogFade(__instance._fogFraction, __instance._fogColor);
                 }
                 if (__instance._shipLandingCamEffectBubbleController != null)
                 {
-                    __instance._shipLandingCamEffectBubbleController.SetFogFade(0, __instance._fogColor);
+                    __instance._shipLandingCamEffectBubbleController.SetFogFade(__instance._fogFraction, __instance._fogColor);
                 }
-                return false;
             }
-            return true;
         }
     }
 }

--- a/NewHorizons/Utility/CoordinateUtilities.cs
+++ b/NewHorizons/Utility/CoordinateUtilities.cs
@@ -28,7 +28,7 @@ namespace NewHorizons.Utility
             var longitude = Mathf.Rad2Deg * Mathf.Atan2(y, x);
 
             // phi
-            float latitude = (Mathf.Rad2Deg * Mathf.Acos(z / dist));
+            float latitude = Mathf.Rad2Deg * Mathf.Acos(z / dist);
 
             return new Vector3(longitude, latitude, dist);
         }

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "owmlVersion": "2.5.2",
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_Randomizer" ],
   "pathsToPreserve": [ "planets", "systems", "translations" ]

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "owmlVersion": "2.5.2",
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_Randomizer" ],
   "pathsToPreserve": [ "planets", "systems", "translations" ]


### PR DESCRIPTION
v1.4.2 Hotfix

I forgot to merge and I just rereleased 1.4.0 as 1.4.1 kill me

- Fixed an issue where a quarter of a planets heightmap was being ruined.
- Fixed bug where fog had to have a tint or it would NRE.
- Improved Bramble dimension exiting fog fix.