### PR TITLE
Update docs_build.yml

### DIFF
--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -23,10 +23,3 @@ jobs:
     uses: './.github/workflows/update_schemas.yml'
     with:
       artifact_name: NewHorizons-Schemas-Debug
-  Build_Docs:
-    name: 'Build Docs'
-    needs: Build
-    if: ${{ needs.Build.outputs.schemas_changed == 'true' }}
-    uses: './.github/workflows/docs_build.yml'
-    with:
-      schemas_artifact: NewHorizons-Schemas-Debug

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -18,8 +18,18 @@ env:
   URL_PREFIX: '/'
   PIPENV_VENV_IN_PROJECT: 1
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
   build:
+    name: Build Docs
     runs-on: ubuntu-latest
     
     steps:
@@ -68,7 +78,16 @@ jobs:
         with:
           path: out/
           
-      - name: Deploy To Pages
-        if: success() && github.ref == 'refs/heads/main'
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    name: Deploy Docs
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v1
           

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -63,15 +63,12 @@ jobs:
           command: run menagerie generate
           
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        if: success() && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v1
         with:
-          name: Built-Docs
           path: out/
           
       - name: Deploy To Pages
         if: success() && github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@4.1.5
-        with:
-          branch: gh-pages 
-          folder: out/
+        uses: actions/deploy-pages@v1
           

--- a/.github/workflows/update_schemas.yml
+++ b/.github/workflows/update_schemas.yml
@@ -8,6 +8,11 @@ on:
         description: 'Name of the artifact to download and check against'
         type: string
 
+# Prevents schemas from trying to update on old commits  
+concurrency:
+  group: "schemas-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   update_schemas:
     runs-on: ubuntu-latest

--- a/docs/content/pages/secret.md
+++ b/docs/content/pages/secret.md
@@ -14,3 +14,6 @@ Uh idk what to put here thought it would be funny haha
 
 ![image](https://user-images.githubusercontent.com/25644444/178856213-44cb0a38-6d3d-4af6-b7f8-0ae6cda8d44a.png)
 
+## Test
+
+aaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
Docs will now directly be deployed to pages without the need for the gh-pages branch