### PR TITLE
Ignore bramble fog alpha

### DIFF
--- a/NewHorizons/Builder/Body/BrambleDimensionBuilder.cs
+++ b/NewHorizons/Builder/Body/BrambleDimensionBuilder.cs
@@ -177,6 +177,7 @@ namespace NewHorizons.Builder.Body
             if (config.fogTint != null)
             {
                 var color = config.fogTint.ToColor();
+                color.a = 1f;
                 fog.fogTint = color;
                 outerFogWarpVolume._fogColor = color;
             }

--- a/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
+++ b/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
@@ -255,6 +255,7 @@ namespace NewHorizons.Builder.Props
             Color fogTint, farFogTint, fogLightTint, lightTint, lightShaftTint, glowTint, fogOverrideTint;
 
             farFogTint = config.fogTint != null ? config.fogTint.ToColor() : new Color(1f, 0.9608f, 0.851f, 1f);
+            farFogTint.a = 1f;
             lightTint = config.lightTint != null ? config.lightTint.ToColor() : Color.white;
 
             Color.RGBToHSV(farFogTint, out var fogH, out var fogS, out var fogV);


### PR DESCRIPTION
It does weird stuff when not 1 and shouldn't be used instead of fog density