### PR TITLE
Do not "fix" backslashes

### DIFF
--- a/NewHorizons/External/NewHorizonsData.cs
+++ b/NewHorizons/External/NewHorizonsData.cs
@@ -22,7 +22,7 @@ namespace NewHorizons.External
 
             try
             {
-                _saveFile = Main.Instance.ModHelper.Storage.Load<NewHorizonsSaveFile>(FileName);
+                _saveFile = Main.Instance.ModHelper.Storage.Load<NewHorizonsSaveFile>(FileName, false);
                 if (!_saveFile.Profiles.ContainsKey(_activeProfileName))
                     _saveFile.Profiles.Add(_activeProfileName, new NewHorizonsProfile());
                 _activeProfile = _saveFile.Profiles[_activeProfileName];

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -460,7 +460,7 @@ namespace NewHorizons
                         Logger.LogVerbose($"Loading system {name}");
 
                         var relativePath = file.Replace(folder, "");
-                        var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>(relativePath);
+                        var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>(relativePath, false);
                         starSystemConfig.Migrate();
                         starSystemConfig.FixCoordinates();
 
@@ -507,7 +507,7 @@ namespace NewHorizons
                 // Has to go before translations for achievements
                 if (File.Exists(folder + "addon-manifest.json"))
                 {
-                    var addonConfig = mod.ModHelper.Storage.Load<AddonConfig>("addon-manifest.json");
+                    var addonConfig = mod.ModHelper.Storage.Load<AddonConfig>("addon-manifest.json", false);
 
                     AchievementHandler.RegisterAddon(addonConfig, mod as ModBehaviour);
                 }
@@ -556,7 +556,7 @@ namespace NewHorizons
             NewHorizonsBody body = null;
             try
             {
-                var config = mod.ModHelper.Storage.Load<PlanetConfig>(relativePath);
+                var config = mod.ModHelper.Storage.Load<PlanetConfig>(relativePath, false);
                 if (config == null)
                 {
                     Logger.LogError($"Couldn't load {relativePath}. Is your Json formatted correctly?");
@@ -568,7 +568,7 @@ namespace NewHorizons
                 if (!SystemDict.ContainsKey(config.starSystem))
                 {
                     // Since we didn't load it earlier there shouldn't be a star system config
-                    var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>($"systems/{config.starSystem}.json");
+                    var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>($"systems/{config.starSystem}.json", false);
                     if (starSystemConfig == null) starSystemConfig = new StarSystemConfig();
                     else Logger.LogWarning($"Loaded system config for {config.starSystem}. Why wasn't this loaded earlier?");
 

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -470,7 +470,7 @@ namespace NewHorizons
                         Logger.LogVerbose($"Loading system {name}");
 
                         var relativePath = file.Replace(folder, "");
-                        var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>(relativePath);
+                        var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>(relativePath, false);
                         starSystemConfig.Migrate();
                         starSystemConfig.FixCoordinates();
 
@@ -535,7 +535,7 @@ namespace NewHorizons
         {
             Logger.LogVerbose($"Loading addon manifest for {mod.ModHelper.Manifest.Name}");
 
-            var addonConfig = mod.ModHelper.Storage.Load<AddonConfig>(file);
+            var addonConfig = mod.ModHelper.Storage.Load<AddonConfig>(file, false);
 
             if (addonConfig.achievements != null) AchievementHandler.RegisterAddon(addonConfig, mod as ModBehaviour);
             if (addonConfig.credits != null) CreditsHandler.RegisterCredits(mod.ModHelper.Manifest.Name, addonConfig.credits);
@@ -574,7 +574,7 @@ namespace NewHorizons
             NewHorizonsBody body = null;
             try
             {
-                var config = mod.ModHelper.Storage.Load<PlanetConfig>(relativePath);
+                var config = mod.ModHelper.Storage.Load<PlanetConfig>(relativePath, false);
                 if (config == null)
                 {
                     Logger.LogError($"Couldn't load {relativePath}. Is your Json formatted correctly?");
@@ -586,7 +586,7 @@ namespace NewHorizons
                 if (!SystemDict.ContainsKey(config.starSystem))
                 {
                     // Since we didn't load it earlier there shouldn't be a star system config
-                    var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>($"systems/{config.starSystem}.json");
+                    var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>($"systems/{config.starSystem}.json", false);
                     if (starSystemConfig == null) starSystemConfig = new StarSystemConfig();
                     else Logger.LogWarning($"Loaded system config for {config.starSystem}. Why wasn't this loaded earlier?");
 


### PR DESCRIPTION
OWML Storage.Load has a thing that replaces \ with /. I think it only exists for backward compatibility. This breaks all escape characters, so this PR disables it.