### PR TITLE
Refactor detail builder, fix parenting issue

### DIFF
--- a/NewHorizons/Builder/Body/ProxyBuilder.cs
+++ b/NewHorizons/Builder/Body/ProxyBuilder.cs
@@ -151,7 +151,7 @@ namespace NewHorizons.Builder.Body
                 {
                     foreach (var detailInfo in body.Config.Props.proxyDetails)
                     {
-                        DetailBuilder.Make(newProxy, null, body.Config, body.Mod, detailInfo);
+                        DetailBuilder.Make(newProxy, null, body.Mod, detailInfo);
                     }
                 }
 

--- a/NewHorizons/Builder/Props/PropBuildManager.cs
+++ b/NewHorizons/Builder/Props/PropBuildManager.cs
@@ -29,7 +29,8 @@ namespace NewHorizons.Builder.Props
                 {
                     try
                     {
-                        DetailBuilder.Make(go, sector, config, mod, detail);
+                        var detailGO = DetailBuilder.Make(go, sector, mod, detail);
+                        DetailBuilder.RegisterDetailInfo(detail, detailGO);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Makes detail making stuff just be in a single method call. The `Make` method now just handles getting the prefab, if its from a path or from an asset bundle. No longer inconsistent when using different detail options like parenting, renaming, removing components, etc.
