### PR TITLE
Toggle Nomai computers with dialogue conditions

### DIFF
--- a/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
+++ b/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
@@ -236,6 +236,16 @@ namespace NewHorizons.Builder.Props.TranslatorText
                         computer._nomaiTextAsset.name = Path.GetFileNameWithoutExtension(info.xmlFile);
                         AddTranslation(xmlContent);
 
+                        if (info.computerStartsOff)
+                        {
+                            computer._startActivated = false;
+                        }
+
+                        if (!string.IsNullOrEmpty(info.computerCondition))
+                        {
+                            ConditionalNomaiComputerToggle.SetUp(computerObject, info.computerCondition, info.computerStartsOff);
+                        }
+
                         // Make sure the computer model is loaded
                         StreamingHandler.SetUpStreaming(computerObject, sector);
 
@@ -266,6 +276,16 @@ namespace NewHorizons.Builder.Props.TranslatorText
                         //fifthRing._baseTextColor = new Color(0.8824, 0.9604, 2.5, 1);
                         //fifthRing._baseTextShadowColor = new Color(0.3529, 0.3843, 1, 0.25);
                         fifthRing._computer = computer;
+
+                        if (info.computerStartsOff)
+                        {
+                            computer._startActivated = false;
+                        }
+
+                        if (!string.IsNullOrEmpty(info.computerCondition))
+                        {
+                            ConditionalNomaiComputerToggle.SetUp(computerObject, info.computerCondition, info.computerStartsOff);
+                        }
 
                         computerObject.SetActive(true);
 

--- a/NewHorizons/Components/ConditionalNomaiComputerToggle.cs
+++ b/NewHorizons/Components/ConditionalNomaiComputerToggle.cs
@@ -1,0 +1,64 @@
+using NewHorizons.Utility.OWML;
+using UnityEngine;
+
+namespace NewHorizons.Components
+{
+    public class ConditionalNomaiComputerToggle : MonoBehaviour
+    {
+        public string dialogueCondition;
+        public bool turnOnWithCondition;
+
+        private NomaiComputer nomaiComputer;
+        private NomaiVesselComputer nomaiVesselComputer;
+
+        public static void SetUp(GameObject computerObject, string condition, bool turnOnWithCondition)
+        {
+            var conditionalNomaiComputerToggleGO = new GameObject($"{computerObject.name}_{condition}");
+            var component = conditionalNomaiComputerToggleGO.AddComponent<ConditionalNomaiComputerToggle>();
+            component.transform.parent = computerObject.transform.parent;
+            component.dialogueCondition = condition;
+            component.turnOnWithCondition = turnOnWithCondition;
+            component.nomaiComputer = computerObject.GetComponent<NomaiComputer>();
+            component.nomaiVesselComputer = computerObject.GetComponent<NomaiVesselComputer>();
+        }
+
+        public void Awake()
+        {
+            GlobalMessenger<string, bool>.AddListener("DialogueConditionChanged", OnDialogueConditionChanged);
+        }
+
+        public void OnDestroy()
+        {
+            GlobalMessenger<string, bool>.RemoveListener("DialogueConditionChanged", OnDialogueConditionChanged);
+        }
+
+        public void OnDialogueConditionChanged(string condition, bool state)
+        {
+            if (condition != dialogueCondition) return;
+
+            if (nomaiComputer != null)
+            {
+                if (state == turnOnWithCondition)
+                {
+                    nomaiComputer.DisplayAllEntries();
+                }
+                else
+                {
+                    nomaiComputer.ClearAllEntries();
+                }
+            }
+
+            if (nomaiVesselComputer != null)
+            {
+                if (state == turnOnWithCondition)
+                {
+                    nomaiVesselComputer.TurnOn();
+                }
+                else
+                {
+                    nomaiVesselComputer.TurnOff();
+                }
+            }
+        }
+    }
+}

--- a/NewHorizons/External/Modules/Props/TranslatorText/TranslatorTextInfo.cs
+++ b/NewHorizons/External/Modules/Props/TranslatorText/TranslatorTextInfo.cs
@@ -13,6 +13,18 @@ namespace NewHorizons.External.Modules.TranslatorText
         public NomaiTextArcInfo[] arcInfo;
 
         /// <summary>
+        /// Turns this computer off when this dialogue condition is set, and back on when it is unset, or the other way around if `computerStartsOff` is true.
+        /// Only revelent when type is `computer` or `preCrashComputer`.
+        /// </summary>
+        public string computerCondition;
+
+        /// <summary>
+        /// Makes this computer turned off by default so the player cannot read the text.
+        /// Only revelent when type is `computer` or `preCrashComputer`.
+        /// </summary>
+        public bool computerStartsOff;
+
+        /// <summary>
         /// The random seed used to pick what the text arcs will look like.
         /// </summary>
         public int seed;


### PR DESCRIPTION

## Minor features

- Added `computerCondition` and `computerStartsOff` to `TranslatorTextInfo`, allowing Nomai computers and pre-crash computers to be turned on and off when a dialogue condition changes (hiding and showing their text with animation and audio).

## Example config

[planets.zip](https://github.com/user-attachments/files/27087709/planets.zip)
(You should spawn on a new body with computers in front of you, and there is a ConditionTriggerVolume that toggles the computers when you get close to them for demonstration purposes.)
