### PR TITLE
Unity text translation

### DIFF
--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -189,9 +189,7 @@ namespace NewHorizons.Builder.Props
                         // Same for translator text
                         if (isFromAssetBundle && component is NomaiText nomaiText)
                         {
-                            NHLogger.LogError("HELLO DID IT WORKED?!?!?!");
                             TranslatorTextBuilder.HandleUnityCreatedNomaiText(nomaiText);
-                            NHLogger.LogError("ERM IT SHOULD HAVE");
                         }
 
                         // copied details need their lanterns fixed

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -1,4 +1,5 @@
 using NewHorizons.Builder.General;
+using NewHorizons.Builder.Props.TranslatorText;
 using NewHorizons.Components;
 using NewHorizons.Components.Orbital;
 using NewHorizons.Components.Props;
@@ -12,6 +13,7 @@ using OWML.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -183,6 +185,13 @@ namespace NewHorizons.Builder.Props
                         if (isFromAssetBundle && component is CharacterDialogueTree dialogue)
                         {
                             DialogueBuilder.HandleUnityCreatedDialogue(dialogue);
+                        }
+                        // Same for translator text
+                        if (isFromAssetBundle && component is NomaiText nomaiText)
+                        {
+                            NHLogger.LogError("HELLO DID IT WORKED?!?!?!");
+                            TranslatorTextBuilder.HandleUnityCreatedNomaiText(nomaiText);
+                            NHLogger.LogError("ERM IT SHOULD HAVE");
                         }
 
                         // copied details need their lanterns fixed

--- a/NewHorizons/Builder/Props/GravityCannonBuilder.cs
+++ b/NewHorizons/Builder/Props/GravityCannonBuilder.cs
@@ -74,6 +74,8 @@ namespace NewHorizons.Builder.Props
             var gravityCannonController = gravityCannonObject.GetComponent<GravityCannonController>();
             var id = ShuttleHandler.GetShuttleID(info.shuttleID);
             gravityCannonController._shuttleID = id;
+            // QM gravity cannon shuttle socket is placed facing the wrong way so we rotate around #1153
+            gravityCannonController._shuttleSocket.Rotate(0f, 180f, 0f, Space.Self);
 
             // Gravity controller checks string length instead of isnullorempty
             gravityCannonController._retrieveShipLogFact = info.retrieveReveal ?? string.Empty;

--- a/NewHorizons/Builder/Props/GravityCannonBuilder.cs
+++ b/NewHorizons/Builder/Props/GravityCannonBuilder.cs
@@ -74,8 +74,6 @@ namespace NewHorizons.Builder.Props
             var gravityCannonController = gravityCannonObject.GetComponent<GravityCannonController>();
             var id = ShuttleHandler.GetShuttleID(info.shuttleID);
             gravityCannonController._shuttleID = id;
-            // QM gravity cannon shuttle socket is placed facing the wrong way so we rotate around #1153
-            gravityCannonController._shuttleSocket.Rotate(0f, 180f, 0f, Space.Self);
 
             // Gravity controller checks string length instead of isnullorempty
             gravityCannonController._retrieveShipLogFact = info.retrieveReveal ?? string.Empty;
@@ -131,6 +129,9 @@ namespace NewHorizons.Builder.Props
             gravityCannonController._forceVolume = platform.FindChild("ForceVolume").GetComponent<DirectionalForceVolume>();
             gravityCannonController._platformTrigger = platform.FindChild("PlatformTrigger").GetComponent<OWTriggerVolume>();
             gravityCannonController._shuttleSocket = platform.FindChild("ShuttleSocket").transform;
+            // QM gravity cannon shuttle socket is placed facing the wrong way so we rotate around #1153
+            gravityCannonController._shuttleSocket.Rotate(0f, 180f, 0f, Space.Self);
+
             gravityCannonController._warpEffect = gravityCannonController._shuttleSocket.GetComponentInChildren<SingularityWarpEffect>();
             gravityCannonController._recallProxyGeometry = gravityCannonController._shuttleSocket.gameObject.FindChild("ShuttleRecallProxy");
 

--- a/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
+++ b/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
@@ -782,5 +782,21 @@ namespace NewHorizons.Builder.Props.TranslatorText
                 TranslationHandler.AddDialogue(text);
             }
         }
+
+        public static void HandleUnityCreatedNomaiText(NomaiText nomaiText)
+        {
+            string xml = OWUtilities.RemoveByteOrderMark(nomaiText._nomaiTextAsset);
+            XmlDocument xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml(xml);
+            XmlNode xmlNode = xmlDocument.SelectSingleNode("NomaiObject");
+            XmlNodeList xmlNodeList = xmlNode.SelectNodes("TextBlock");
+
+            foreach (object obj in xmlNodeList)
+            {
+                XmlNode xmlNode2 = (XmlNode)obj;
+                var text = xmlNode2.SelectSingleNode("Text").InnerText;
+                TranslationHandler.AddDialogue(text);
+            }
+        }
     }
 }

--- a/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
@@ -17,27 +17,25 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.Initialize))]
     public static bool SlideCollectionContainer_Initialize(SlideCollectionContainer __instance)
     {
-        if (__instance is NHSlideCollectionContainer container)
-        {
-            if (__instance._initialized)
-                return false;
-            __instance.SetupReadFlags();
-            __instance.RegisterPerSlideCompletion();
-            if (__instance.streamingTexturesAvailable)
-                __instance.SetupStreaming();
-            __instance.BuildMusicRangesIndex();
-            __instance._changeSlidesAllowed = true;
-            __instance._initialized = true;
-            __instance._slideCollection.isVision = __instance._owningItem == null;
-            foreach (var factID in __instance._playWithShipLogFacts)
-            {
-                var fact = Locator.GetShipLogManager().GetFact(factID);
-                fact?.RegisterSlideCollection(__instance._slideCollection);
-                // in original it logs. we dont want that here ig
-            }
+        // We used to only do this for our custom class
+        // However the error logs for DLC slides happen in all new systems so we just use this always to not log
+        if (__instance._initialized)
             return false;
+        __instance.SetupReadFlags();
+        __instance.RegisterPerSlideCompletion();
+        if (__instance.streamingTexturesAvailable)
+            __instance.SetupStreaming();
+        __instance.BuildMusicRangesIndex();
+        __instance._changeSlidesAllowed = true;
+        __instance._initialized = true;
+        __instance._slideCollection.isVision = __instance._owningItem == null;
+        foreach (var factID in __instance._playWithShipLogFacts)
+        {
+            var fact = Locator.GetShipLogManager().GetFact(factID);
+            fact?.RegisterSlideCollection(__instance._slideCollection);
+            // In original it logs here. We dont want that because it spams when loading
         }
-        return true;
+        return false;
     }
 
     [HarmonyPostfix]

--- a/NewHorizons/External/Configs/TranslationConfig.cs
+++ b/NewHorizons/External/Configs/TranslationConfig.cs
@@ -9,22 +9,22 @@ namespace NewHorizons.External.Configs
     public class TranslationConfig
     {
         /// <summary>
-        /// Translation table for dialogue
+        /// Translation table for dialogue and Nomai text.
         /// </summary>
         public Dictionary<string, string> DialogueDictionary;
 
         /// <summary>
-        /// Translation table for Ship Log (entries, facts, etc)
+        /// Translation table for Ship Log (entries, facts, etc).
         /// </summary>
         public Dictionary<string, string> ShipLogDictionary;
 
         /// <summary>
-        /// Translation table for UI elements
+        /// Translation table for UI elements e.g., item names, planet names, HUD notification. Basically anything that is not dialogue, Nomai text, or ship logs.
         /// </summary>
         public Dictionary<string, string> UIDictionary;
 
         /// <summary>
-        /// Translation table for other text, will be taken verbatim without correcting CDATA
+        /// Translation table for other text, will be taken verbatim without correcting CDATA. This is meant only for use in your custom code with the GetTranslationForOtherText API method.
         /// </summary>
         public Dictionary<string, string> OtherDictionary;
 

--- a/NewHorizons/Schemas/translation_schema.json
+++ b/NewHorizons/Schemas/translation_schema.json
@@ -6,28 +6,28 @@
   "properties": {
     "DialogueDictionary": {
       "type": "object",
-      "description": "Translation table for dialogue",
+      "description": "Translation table for dialogue and Nomai text.",
       "additionalProperties": {
         "type": "string"
       }
     },
     "ShipLogDictionary": {
       "type": "object",
-      "description": "Translation table for Ship Log (entries, facts, etc)",
+      "description": "Translation table for Ship Log (entries, facts, etc).",
       "additionalProperties": {
         "type": "string"
       }
     },
     "UIDictionary": {
       "type": "object",
-      "description": "Translation table for UI elements",
+      "description": "Translation table for UI elements e.g., item names, planet names, HUD notification. Basically anything that is not dialogue, Nomai text, or ship logs.",
       "additionalProperties": {
         "type": "string"
       }
     },
     "OtherDictionary": {
       "type": "object",
-      "description": "Translation table for other text, will be taken verbatim without correcting CDATA",
+      "description": "Translation table for other text, will be taken verbatim without correcting CDATA. This is meant only for use in your custom code with the GetTranslationForOtherText API method.",
       "additionalProperties": {
         "type": "string"
       }

--- a/NewHorizons/Utility/DebugTools/DebugRaycaster.cs
+++ b/NewHorizons/Utility/DebugTools/DebugRaycaster.cs
@@ -2,6 +2,7 @@ using NewHorizons.Handlers;
 using NewHorizons.Utility.Files;
 using NewHorizons.Utility.Geometry;
 using NewHorizons.Utility.OWML;
+using System.Globalization;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -144,7 +145,12 @@ namespace NewHorizons.Utility.DebugTools
             }
         }
 
-        internal string Vector3ToString(Vector3 v) => $"{{\"x\": {v.x}, \"y\": {v.y}, \"z\": {v.z}}}";
+        internal string Vector3ToString(Vector3 v)
+        {
+            static string DecimalString(float f) => f.ToString(CultureInfo.InvariantCulture);
+
+            return $"{{\"x\": {DecimalString(v.x)}, \"y\": {DecimalString(v.y)}, \"z\": {DecimalString(v.z)}}}";
+        } 
 
         private void DestroyDebugSpheres()
         {

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.29.5",
+  "version": "1.29.6",
   "owmlVersion": "2.12.1",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Improvements

- Nomai text made in Unity and loaded through an asset bundle will now be properly translated as if NH had made it itself.
- Removed "Failed to locate ship log fact" error spam when loading custom systems
- Nomai shuttle return warp rotation now faces the walkway (Fixes #1153)

## Bug fixes

- Debug raycast now prints with decimal points regardless of PC language (Fixes #1155, #1154)
