### PR TITLE
Bug fixes or something

### DIFF
--- a/NewHorizons/Builder/Props/ItemBuilder.cs
+++ b/NewHorizons/Builder/Props/ItemBuilder.cs
@@ -37,6 +37,16 @@ namespace NewHorizons.Builder.Props
 
             var itemType = GetOrCreateItemType(itemTypeName);
 
+            if (itemType == ItemType.WarpCore)
+            {
+                // WarpCores cannot be naively made by NH #1121
+                NHLogger.LogError($"Your custom item {itemName} cannot use the {ItemType.WarpCore} type. " +
+                    $"These items have more complicated code that cannot be handled by NH alone. " +
+                    $"If you really want to implement a WarpCore like the one used to power the Vessel, " +
+                    $"either just duplicate an existing warp core prop or write custom code.");
+                return null;
+            }
+
             var item = go.GetAddComponent<NHItem>();
             item._sector = sector;
             item._interactable = info.interactRange > 0f;

--- a/NewHorizons/External/Modules/CloakModule.cs
+++ b/NewHorizons/External/Modules/CloakModule.cs
@@ -7,7 +7,8 @@ namespace NewHorizons.External.Modules
     public class CloakModule
     {
         /// <summary>
-        /// Radius of the cloaking field around the planet. For the Stranger this is 3000
+        /// Radius of the cloaking field around the planet. For the Stranger this is 3000. 
+        /// When using the default proportional values, the cloak should be 6x larger than the object it's hiding in order to work nicely.
         /// </summary>
         public float radius;
 

--- a/NewHorizons/External/Modules/Props/Item/ItemInfo.cs
+++ b/NewHorizons/External/Modules/Props/Item/ItemInfo.cs
@@ -19,7 +19,7 @@ namespace NewHorizons.External.Modules.Props.Item
         /// </summary>
         public string name;
         /// <summary>
-        /// The type of the item, which determines its orientation when held and what sockets it fits into. This can be a custom string, or a vanilla ItemType (Scroll, WarpCore, SharedStone, ConversationStone, Lantern, SlideReel, DreamLantern, or VisionTorch). Defaults to the item name.
+        /// The type of the item, which determines its orientation when held and what sockets it fits into. This can be a custom string, or a vanilla ItemType (Scroll, SharedStone, ConversationStone, Lantern, SlideReel, DreamLantern, or VisionTorch). Defaults to the item name. Note: This cannot be the base game WarpCore item type as those have complicated custom behaviour.
         /// </summary>
         public string itemType;
         /// <summary>

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -349,15 +349,11 @@ namespace NewHorizons
 
             // Caches of other assets only have to be cleared if we changed star systems
             if (ForceClearCaches || CurrentStarSystem != _previousStarSystem)
-            {
-                var shouldClearPreloadedBundles = ForceClearCaches;
-
-                ForceClearCaches = false;
-                
+            {               
                 NHLogger.Log($"Changing star system from {_previousStarSystem} to {CurrentStarSystem} - Clearing system-specific caches!");
                 ImageUtilities.ClearCache();
                 AudioUtilities.ClearCache();
-                AssetBundleUtilities.ClearCache(shouldClearPreloadedBundles);
+                AssetBundleUtilities.ClearCache(ForceClearCaches);
                 ProcGenBuilder.ClearCache();
             }
 
@@ -376,6 +372,24 @@ namespace NewHorizons
             var isCreditsFast = scene.name == LoadManager.SceneToName(OWScene.Credits_Fast);
             var isCreditsFinal = scene.name == LoadManager.SceneToName(OWScene.Credits_Final);
             var isPostCredits = scene.name == LoadManager.SceneToName(OWScene.PostCreditsScene);
+
+            if (ForceClearCaches)
+            {
+                // When we force clear the cache we have to ensure that bundles that are normally preloaded are loaded properly
+                foreach (var mod in Main.MountedAddons)
+                {
+                    if (AddonConfigs.TryGetValue(mod, out var config) && config.preloadAssetBundles != null)
+                    {
+                        foreach (var bundle in config.preloadAssetBundles)
+                        {
+                            AssetBundleUtilities.PreloadBundleSynchronously(bundle, mod);
+                        }
+                    }
+                }
+            }
+
+            ForceClearCaches = false;
+
 
             if (isSolarSystem)
             {
@@ -764,7 +778,7 @@ namespace NewHorizons
 
             var starSystemName = starSystemConfig.name;
 
-            if (starSystemName != "SolarSystem" && starSystemName != "EyeOfTheUniverse")
+            if (starSystemName != "SolarSystem" && starSystemName != "EyeOfTheUniverse" && starSystemName != "Jam3" && starSystemName != "Jam5")
             {
                 bool hasSpaces = starSystemName.Contains(" ");
                 bool missingNamespace = !starSystemName.Contains(".");
@@ -944,7 +958,7 @@ namespace NewHorizons
             {
                 MenuHandler.RegisterOneTimePopup(mod, TranslationHandler.GetTranslation(addonConfig.popupMessage, TranslationHandler.TextType.UI), addonConfig.repeatPopup);
             }
-            if (addonConfig.preloadAssetBundles != null)
+            if (addonConfig.preloadAssetBundles != null && !ForceClearCaches)
             {
                 foreach (var bundle in addonConfig.preloadAssetBundles)
                 {

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -350,12 +350,14 @@ namespace NewHorizons
             // Caches of other assets only have to be cleared if we changed star systems
             if (ForceClearCaches || CurrentStarSystem != _previousStarSystem)
             {
+                var shouldClearPreloadedBundles = ForceClearCaches;
+
                 ForceClearCaches = false;
                 
                 NHLogger.Log($"Changing star system from {_previousStarSystem} to {CurrentStarSystem} - Clearing system-specific caches!");
                 ImageUtilities.ClearCache();
                 AudioUtilities.ClearCache();
-                AssetBundleUtilities.ClearCache();
+                AssetBundleUtilities.ClearCache(shouldClearPreloadedBundles);
                 ProcGenBuilder.ClearCache();
             }
 

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -881,7 +881,7 @@
       "properties": {
         "radius": {
           "type": "number",
-          "description": "Radius of the cloaking field around the planet. For the Stranger this is 3000",
+          "description": "Radius of the cloaking field around the planet. For the Stranger this is 3000. \nWhen using the default proportional values, the cloak should be 6x larger than the object it's hiding in order to work nicely.",
           "format": "float"
         },
         "cloakScaleDist": {

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1129,7 +1129,7 @@
         },
         "itemType": {
           "type": "string",
-          "description": "The type of the item, which determines its orientation when held and what sockets it fits into. This can be a custom string, or a vanilla ItemType (Scroll, WarpCore, SharedStone, ConversationStone, Lantern, SlideReel, DreamLantern, or VisionTorch). Defaults to the item name."
+          "description": "The type of the item, which determines its orientation when held and what sockets it fits into. This can be a custom string, or a vanilla ItemType (Scroll, SharedStone, ConversationStone, Lantern, SlideReel, DreamLantern, or VisionTorch). Defaults to the item name. Note: This cannot be the base game WarpCore item type as those have complicated custom behaviour."
         },
         "interactRange": {
           "type": "number",

--- a/NewHorizons/Utility/DebugTools/DebugReload.cs
+++ b/NewHorizons/Utility/DebugTools/DebugReload.cs
@@ -31,6 +31,8 @@ namespace NewHorizons.Utility.DebugTools
 
             Main.Instance.ResetConfigs();
 
+            Main.Instance.ForceClearCaches = true;
+
             try
             {
                 foreach (IModBehaviour mountedAddon in Main.MountedAddons)
@@ -42,9 +44,6 @@ namespace NewHorizons.Utility.DebugTools
             {
                 NHLogger.LogWarning("Error While Reloading");
             }
-
-            Main.Instance.ForceClearCaches = true;
-
 
             SearchUtilities.Find("/PauseMenu/PauseMenuManagers").GetComponent<PauseMenuManager>().OnSkipToNextTimeLoop();
 

--- a/NewHorizons/Utility/Files/AssetBundleUtilities.cs
+++ b/NewHorizons/Utility/Files/AssetBundleUtilities.cs
@@ -1,3 +1,4 @@
+using Epic.OnlineServices;
 using NewHorizons.Utility.OWML;
 using OWML.Common;
 using OWML.ModHelper;
@@ -6,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace NewHorizons.Utility.Files
 {
@@ -76,6 +78,27 @@ namespace NewHorizons.Utility.Files
                 NHLogger.Log($"Finished preloading bundle {assetBundleRelativeDir} - {_loadingBundles.Count} left");
                 AssetBundles[key] = (request.assetBundle, true);
             };
+        }
+
+        public static void PreloadBundleSynchronously(string assetBundleRelativeDir, IModBehaviour mod)
+        {
+            // Called in the case of clearing the cache, where we need the preloading bundles loaded immediately
+            string key = Path.GetFileName(assetBundleRelativeDir);
+            var completePath = Path.Combine(mod.ModHelper.Manifest.ModFolderPath, assetBundleRelativeDir);
+
+            if (!AssetBundles.ContainsKey(key))
+            {
+                NHLogger.Log($"Preloading bundle {assetBundleRelativeDir} synchronously");
+                var bundle = AssetBundle.LoadFromFile(completePath);
+                if (bundle == null)
+                {
+                    NHLogger.LogError($"Couldn't load AssetBundle at [{completePath}] for [{mod.ModHelper.Manifest.Name}]");
+                }
+                else
+                {
+                    AssetBundles[key] = (bundle, true);
+                }
+            }
         }
 
         /// <summary>

--- a/NewHorizons/Utility/Files/AssetBundleUtilities.cs
+++ b/NewHorizons/Utility/Files/AssetBundleUtilities.cs
@@ -35,11 +35,11 @@ namespace NewHorizons.Utility.Files
             return bundle;
         }
 
-        public static void ClearCache()
+        public static void ClearCache(bool clearKeepLoaded = false)
         {
             foreach (var pair in AssetBundles)
             {
-                if (!pair.Value.keepLoaded)
+                if (!pair.Value.keepLoaded || clearKeepLoaded)
                 {
                     if (pair.Value.bundle == null)
                     {
@@ -52,7 +52,14 @@ namespace NewHorizons.Utility.Files
                 }
 
             }
-            AssetBundles = AssetBundles.Where(x => x.Value.keepLoaded).ToDictionary(x => x.Key, x => x.Value);
+            if (clearKeepLoaded)
+            {
+                AssetBundles.Clear();
+            }
+            else
+            {
+                AssetBundles = AssetBundles.Where(x => x.Value.keepLoaded).ToDictionary(x => x.Key, x => x.Value);
+            }
             _prefabCache.Clear();
         }
 

--- a/NewHorizons/Utility/SearchUtilities.cs
+++ b/NewHorizons/Utility/SearchUtilities.cs
@@ -162,7 +162,8 @@ namespace NewHorizons.Utility
             // To try to be somewhat correct check that the parent is right. Fixes #1136, ensures GhostBirds and Anglerfish details are more stable
             if (!string.IsNullOrEmpty(parent))
             {
-                go = possibleMatches.FirstOrDefault(x => parent == null || x.transform.parent.name == parent);
+                // multiple enumeration but its fine
+                go = possibleMatches.FirstOrDefault(x => x.transform.parent.name == parent);
                 if (go == null)
                 {
                     go = possibleMatches.FirstOrDefault();
@@ -176,6 +177,8 @@ namespace NewHorizons.Utility
             if (go)
             {
                 CachedGameObjects.Add(path, go);
+                NHLogger.LogWarning($"Found object with name {name} at path {go.transform.GetPath()}\n" +
+                                    $"Check that this is the correct object, then use the given path in your config or code.");
                 Profiler.EndSample();
                 return go;
             }

--- a/NewHorizons/Utility/SearchUtilities.cs
+++ b/NewHorizons/Utility/SearchUtilities.cs
@@ -154,10 +154,25 @@ namespace NewHorizons.Utility
 
             Profiler.BeginSample("3");
             var name = names.Last();
-            if (warn) NHLogger.LogWarning($"Couldn't find object in path {path}, will look for potential matches for name {name}");
+            var parent = names.Length >= 2 ? names[names.Length - 2] : null;
+            if (warn) NHLogger.LogWarning($"Couldn't find object in path {path}, will look for potential matches for name {name} with parent {parent}");
             // 3: find resource to include inactive objects (but skip prefabs)
-            go = Resources.FindObjectsOfTypeAll<GameObject>()
-                .FirstOrDefault(x => x.name == name && x.scene.name != null);
+            var possibleMatches = Resources.FindObjectsOfTypeAll<GameObject>()
+                .Where(x => x.name == name && x.scene.name != null);
+            // To try to be somewhat correct check that the parent is right. Fixes #1136, ensures GhostBirds and Anglerfish details are more stable
+            if (!string.IsNullOrEmpty(parent))
+            {
+                go = possibleMatches.FirstOrDefault(x => parent == null || x.transform.parent.name == parent);
+                if (go == null)
+                {
+                    go = possibleMatches.FirstOrDefault();
+                }
+            }
+            else
+            {
+                go = possibleMatches.FirstOrDefault();
+            }
+
             if (go)
             {
                 CachedGameObjects.Add(path, go);

--- a/docs/src/content/docs/guides/dialogue.mdx
+++ b/docs/src/content/docs/guides/dialogue.mdx
@@ -3,6 +3,8 @@ title: Dialogue
 description: Guide to making dialogue in New Horizons
 ---
 
+import { Aside } from "@astrojs/starlight/components";
+
 This page goes over how to use dialogue in New Horizons.
 
 ## Understanding Dialogue
@@ -18,6 +20,10 @@ A node is a set of pages shown to the player followed by options the player can 
 ### Conditions
 
 In dialogue, the available conversation topics can be limited by what the player knows, defined using dialogue conditions, persistent conditions, and ship log facts. Dialogue can also set conditions to true or false, and reveal ship log facts to the player. This is covered in detail later on this page.
+
+<Aside title="On naming conditions">
+Consider prefixing all your dialogue conditions with the name of your mod to prevent incompatibilities with other mods! For example instead of having a condition called `SPOKE_TO_NOMAI` try `[YOUR_MOD_NAME]_SPOKE_TO_NOMAI`.
+</Aside>
 
 ### Remote Trigger
 

--- a/docs/src/content/docs/guides/ship-log.mdx
+++ b/docs/src/content/docs/guides/ship-log.mdx
@@ -3,6 +3,8 @@ title: Ship Log
 description: A guide to editing the ship log in New Horizons
 ---
 
+import { Aside } from "@astrojs/starlight/components";
+
 ## Understanding Ship Logs
 
 First thing's first, I'll define some terminology regarding ship logs in the game, and how ship logs are structured.
@@ -15,6 +17,10 @@ An entry is split up into facts, a fact can either be a rumor fact or an explore
 
 ![entryExample](@/assets/docs-images/ship_log/entry_example.webp)
 _In red you can see an entry, in green you can see the entry's facts_
+
+<Aside title="On naming facts and entries">
+Consider prefixing all your ship log facts and entries with the name of your mod to prevent incompatibilities with other mods! For example instead of having a fact called `SECRET_LEARNED` try `[YOUR_MOD_NAME]_SECRET_LEARNED`.
+</Aside>
 
 #### Curiosities
 


### PR DESCRIPTION
## Bug fixes

- Log errors and prevent users from creating NHItems with the WarpCore type, as those must extend the WarpCoreItem class and should be done with custom code. #1121 
- Fixed an issue when reloading configs while having preloaded bundles. #1101 and #1130.
- Fixed an issue where the wrong GhostBird prefab could be taken by a detail. When failing to find an object by path, SearchUtilities now checks for an object with the correct name and correct parent name. Fixes #1136.

## Documentation
- Recommended prefixing ship log fact/entry IDs and dialogue condition IDs with the name of your mod to prevent possible incompatibility issues. #1087
- Documented recommended cloak sizes (at least x6 the size of the planet) #1089
